### PR TITLE
Hardcoded localhost fix in showMeetingLinks

### DIFF
--- a/WebRTCMeeting/README.md
+++ b/WebRTCMeeting/README.md
@@ -25,6 +25,8 @@ Welcome to the official Wowza Media Systems WebRTC client examples. These exampl
 
 4. In the **[wowza-install-directory]/webrtcmeetingfiles/meeting/** folder, open **meeting/js/webrtc-play.js** and **meeting/js/webrtc-publish.js**  and edit them to replace the `[YOUR CERT NAME HERE]` entry with the name of the SSL certificate you are using.
 
+5. In the same folder,**[wowza-install-directory]/webrtcmeetingfiles/meeting/**, open **showMeetingLinks.html** and edit them to replace the `[YOUR CERT NAME HERE]` entry with the name of the SSL certificate you are using.
+
 5. In the **[wowza-install-directory]/conf/** folder open the **VHost.xml** file and locate the <HostPort> container for port 443 with SSL.
 
 	>	**Note:**  The default port for SSL is 443, however if you are using another port these same changes apply. 

--- a/WebRTCMeeting/meeting/showMeetingLinks.html
+++ b/WebRTCMeeting/meeting/showMeetingLinks.html
@@ -1,5 +1,7 @@
 
 
 Meeting ID: <%__MEETING_ID__%><br/>
-Participant One Link: <a href="http://127.0.0.1:1935/<%__LOCATION__%>/createMeeting.html?streamID=<%__STREAMID_ONE__%>">Participant One</a><br/>
-Participant Two Link: <a href="http://127.0.0.1:1935/<%__LOCATION__%>/createMeeting.html?streamID=<%__STREAMID_TWO__%>">Participant Two</a><br/>
+Participant One Link: <a href="https://[YOUR CERT NAME HERE].streamlock.net/<%__LOCATION__%>/createMeeting.html?streamID=<%__STREAMID_ONE__%>">Participant One</
+a><br/>
+Participant Two Link: <a href="https://[YOUR CERT NAME HERE].streamlock.net/<%__LOCATION__%>/createMeeting.html?streamID=<%__STREAMID_TWO__%>">Participant Two</
+a><br/>


### PR DESCRIPTION
Readme and small html code fix to make the values more obvious to change to dev's streamlock cert.