### PR TITLE
The video bitrate constaint emplaced by the "b=AS" value in the SDP i…

### DIFF
--- a/src/jquery-example/lib/WowzaMungeSDP.js
+++ b/src/jquery-example/lib/WowzaMungeSDP.js
@@ -295,7 +295,7 @@ export function mungeSDPPublish(sdpStr, mungeData) {
         if ('audio'.localeCompare(sdpSection) == 0)
         {
           if (mungeData.audioBitrate !== '') {
-            let audioBitrate = parseInt(mungeData.audioBitrate) * 1000;
+            let audioBitrate = parseInt(mungeData.audioBitrate);
             let audioBitrateTIAS = parseInt(mungeData.audioBitrate) * 1000 * 0.95 - (50 * 40 * 8);
             sdpStrRet += "\r\nb=TIAS:"+audioBitrateTIAS+"\r\n";
             sdpStrRet += "b=AS:"+audioBitrate+"\r\n";
@@ -306,7 +306,7 @@ export function mungeSDPPublish(sdpStr, mungeData) {
         if ('video'.localeCompare(sdpSection) == 0)
         {
           if (mungeData.videoBitrate !== '') {
-            let videoBitrate = parseInt(mungeData.videoBitrate) * 1000;
+            let videoBitrate = parseInt(mungeData.videoBitrate);
             let videoBitrateTIAS = parseInt(mungeData.videoBitrate) * 1000 * 0.95 - (50 * 40 * 8);
             sdpStrRet += "\r\nb=TIAS:"+videoBitrateTIAS*1000+"\r\n";
             sdpStrRet += "b=AS:"+videoBitrate+"\r\n";

--- a/src/react-example/src/webrtc/mungeSDP.js
+++ b/src/react-example/src/webrtc/mungeSDP.js
@@ -287,7 +287,7 @@ export function mungeSDPPublish(sdpStr, mungeData) {
         if ('audio'.localeCompare(sdpSection) === 0)
         {
           if (mungeData.audioBitrate !== '') {
-            let audioBitrate = parseInt(mungeData.audioBitrate) * 1000;
+            let audioBitrate = parseInt(mungeData.audioBitrate);
             let audioBitrateTIAS = parseInt(mungeData.audioBitrate) * 1000 * 0.95 - (50 * 40 * 8);
             sdpStrRet += "\r\nb=TIAS:"+audioBitrateTIAS+"\r\n";
             sdpStrRet += "b=AS:"+audioBitrate+"\r\n";
@@ -298,7 +298,7 @@ export function mungeSDPPublish(sdpStr, mungeData) {
         if ('video'.localeCompare(sdpSection) === 0)
         {
           if (mungeData.videoBitrate !== '') {
-            let videoBitrate = parseInt(mungeData.videoBitrate) * 1000;
+            let videoBitrate = parseInt(mungeData.videoBitrate);
             let videoBitrateTIAS = parseInt(mungeData.videoBitrate) * 1000 * 0.95 - (50 * 40 * 8);
             sdpStrRet += "\r\nb=TIAS:"+videoBitrateTIAS+"\r\n";
             sdpStrRet += "b=AS:"+videoBitrate+"\r\n";


### PR DESCRIPTION
…s being multiplied by 1000, only in the Safari and Firefox browsers. For Safari, this causes publishing client bitrates to climb to excessive levels, despite this value not being intended to be interpreted as a target of optimal bitrate for a video encoder.