### PR TITLE
#40911: Modify sdpDescription to enable publisher for Safari

### DIFF
--- a/src/jquery-example/lib/WowzaMungeSDP.js
+++ b/src/jquery-example/lib/WowzaMungeSDP.js
@@ -214,20 +214,20 @@ export function mungeSDPPublish(sdpStr, mungeData) {
     if (sdpLine.length <= 0)
       continue;
 
-    if (browserDetails.browser === 'chrome') {
-      let audioMLines;
-      if (sdpLine.indexOf("m=audio") == 0 && audioIndex !== -1) {
-        audioMLines = sdpLine.split(" ");
-        sdpStrRet += audioMLines[0] + " " + audioMLines[1] + " " + audioMLines[2] + " " + audioIndex + "\r\n";
-        continue;
-      }
-
-      if (sdpLine.indexOf("m=video") == 0 && videoIndex !== -1) {
-        audioMLines = sdpLine.split(" ");
-        sdpStrRet += audioMLines[0] + " " + audioMLines[1] + " " + audioMLines[2] + " " + videoIndex + "\r\n";
-        continue;
-      }
+    
+    let audioMLines;
+    if (sdpLine.indexOf("m=audio") == 0 && audioIndex !== -1) {
+      audioMLines = sdpLine.split(" ");
+      sdpStrRet += audioMLines[0] + " " + audioMLines[1] + " " + audioMLines[2] + " " + audioIndex + "\r\n";
+      continue;
     }
+
+    if (sdpLine.indexOf("m=video") == 0 && videoIndex !== -1) {
+      audioMLines = sdpLine.split(" ");
+      sdpStrRet += audioMLines[0] + " " + audioMLines[1] + " " + audioMLines[2] + " " + videoIndex + "\r\n";
+      continue;
+    }
+  
 
     sdpStrRet += sdpLine;
 
@@ -244,7 +244,7 @@ export function mungeSDPPublish(sdpStr, mungeData) {
       hitMID = false;
     }
 
-    if (browserDetails.browser === 'chrome') {
+    if (browserDetails.browser === 'chrome' || browserDetails.browser === 'safari') {
       if (sdpLine.indexOf("a=mid:") === 0 || sdpLine.indexOf("a=rtpmap") == 0) {
         if (!hitMID) {
           if ('audio'.localeCompare(sdpSection) == 0) {
@@ -288,7 +288,7 @@ export function mungeSDPPublish(sdpStr, mungeData) {
       }
     }
 
-    if (browserDetails.browser === 'firefox' || browserDetails.browser === 'safari') {
+    if (browserDetails.browser === 'firefox') {
       if ( sdpLine.indexOf("c=IN") ==0 )
       {
 

--- a/src/jquery-example/lib/WowzaWebRTCPublish.js
+++ b/src/jquery-example/lib/WowzaWebRTCPublish.js
@@ -3,7 +3,7 @@
  * This code is licensed pursuant to the BSD 3-Clause License.
  */
 
-import { mungeSDPPublish } from './WowzaMungeSDP.js';
+import mungeSDPPublish from './WowzaMungeSDP.js';
 import WowzaPeerConnectionPublish from './WowzaPeerConnectionPublish.js';
 import SoundMeter from './SoundMeter.js';
 


### PR DESCRIPTION
We modify the way the sdpDescription is processed for Safari and use the same implementation as the one we use for chrome.