### PR TITLE
ENG-941: Munge sdp hotfix

### DIFF
--- a/src/jquery-example/lib/WowzaWebRTCPlay.js
+++ b/src/jquery-example/lib/WowzaWebRTCPlay.js
@@ -3,7 +3,9 @@
  * This code is licensed pursuant to the BSD 3-Clause License.
  */
 
-import { mungeSDPPlay } from './WowzaMungeSDP.js';
+// import { mungeSDPPlay } from './WowzaMungeSDP.js';
+const mungeSDPPlay = null; // hotfix
+
 import WowzaPeerConnectionPlay from './WowzaPeerConnectionPlay.js';
 
 class WowzaWebRTCPlay

--- a/src/jquery-example/lib/WowzaWebRTCPublish.js
+++ b/src/jquery-example/lib/WowzaWebRTCPublish.js
@@ -3,7 +3,7 @@
  * This code is licensed pursuant to the BSD 3-Clause License.
  */
 
-import mungeSDPPublish from './WowzaMungeSDP.js';
+// import mungeSDPPublish from './WowzaMungeSDP.js';
 import WowzaPeerConnectionPublish from './WowzaPeerConnectionPublish.js';
 import SoundMeter from './SoundMeter.js';
 
@@ -509,7 +509,7 @@ const start = () =>
     streamInfo:currentState.streamInfo,
     mediaInfo:currentState.mediaInfo,
     userData:currentState.userData,
-    mungeSDP:mungeSDPPublish,
+    mungeSDP: null, // hotfix
     onconnectionstatechange: onconnectionstatechange,
     onstop:onstop,
     onstats:callbacks.onStats || undefined,

--- a/src/react-example/src/webrtc/startPlay.js
+++ b/src/react-example/src/webrtc/startPlay.js
@@ -1,4 +1,4 @@
-import { mungeSDPPlay } from './mungeSDP';
+// import { mungeSDPPlay } from './mungeSDP';
 import stopPlay from './stopPlay';
 
 // Utilities
@@ -112,9 +112,8 @@ const websocketOnMessage = (event, playSettings, peerConnection, websocket, call
 
     if (msgJSON['sdp'] != null) {
 
-      msgJSON.sdp.sdp = mungeSDPPlay(msgJSON.sdp.sdp);
-
-      console.log("SDP Data: " + msgJSON.sdp.sdp);
+      // msgJSON.sdp.sdp = mungeSDPPlay(msgJSON.sdp.sdp);
+      // console.log("SDP Data: " + msgJSON.sdp.sdp);
 
       peerConnection
       .setRemoteDescription(new RTCSessionDescription(msgJSON.sdp))

--- a/src/react-example/src/webrtc/startPublish.js
+++ b/src/react-example/src/webrtc/startPublish.js
@@ -1,4 +1,4 @@
-import { mungeSDPPublish } from './mungeSDP';
+// import { mungeSDPPublish } from './mungeSDP';
 
 // Utilities
 
@@ -36,10 +36,10 @@ const peerConnectionCreateOfferSuccess = (description, publishSettings, websocke
   if (publishSettings.audioCodec != null)
     mungeData.audioCodec = publishSettings.audioCodec;
 
-  description.sdp = mungeSDPPublish(description.sdp, mungeData);
+  // description.sdp = mungeSDPPublish(description.sdp, mungeData);
 
-  console.log("peerConnectionCreateOfferSuccess: Setting local description SDP: ");
-  console.log(description.sdp);
+  // console.log("peerConnectionCreateOfferSuccess: Setting local description SDP: ");
+  // console.log(description.sdp);
 
   peerConnection
     .setLocalDescription(description)


### PR DESCRIPTION
Commented out mungeSDP functions from both player and publisher modules as a hotfix to address changes related to Chrome 127 update. 
This was tested with WSE 4.8.28, the changes are meant as a hotfix and more work should be done to replicate the mungeSDP functionality using WebRTC API methods instead.