### PR TITLE
ENG-3855: Fix changing cameras in mobile and desktop

### DIFF
--- a/v2/src/react-example/src/components/media/CompositorUserMedia.js
+++ b/v2/src/react-example/src/components/media/CompositorUserMedia.js
@@ -9,12 +9,19 @@ import * as PublishSettingsActions from '../../actions/publishSettingsActions';
 import getUserMedia from '../../webrtc/getUserMedia';
 import getDisplayScreen from '../../webrtc/getDisplayScreen';
 
+// Mobile hardware (iOS/Android) typically only allows one camera open at a time —
+// the ISP is single-tenant, so keeping multiple camera tracks live raises
+// NotReadableError on the second acquisition.
+const isMobile = () => /Android|webOS|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent);
+
 const getPermissions = async (dispatch) => {
 
   let gotPermissions = false;
   try
   {
-    await getUserMedia({video:videoConstraintsByFrameSize.default,audio:true});
+    const stream = await getUserMedia({video:videoConstraintsByFrameSize.default,audio:true});
+    // Release the probe tracks so they don't hold the camera on mobile.
+    stream.getTracks().forEach((t) => t.stop());
     gotPermissions = true;
   }
   catch(e) {}
@@ -26,7 +33,7 @@ const loadUserMediaForCameras  = async (dispatch, cameras, videoTracksMap) => {
   let newVideoTracksMap = {...videoTracksMap};
   for (let i = 0; i < cameras.length; i++)
   {
-    let constraints = { video:videoConstraintsByFrameSize.default, audio:false };
+    let constraints = { video:{...videoConstraintsByFrameSize.default}, audio:false };
     constraints.video.deviceId = cameras[i].deviceId;
 
     try {
@@ -38,9 +45,80 @@ const loadUserMediaForCameras  = async (dispatch, cameras, videoTracksMap) => {
       }
 
     } catch (e) {
+      console.error("Loading camera had error", e)
     }
   }
   dispatch({type:MediaActions.SET_MEDIA_TRACKS,videoTracksMap:newVideoTracksMap});
+}
+
+// Serialize mobile camera switches. The effect can fire multiple times in
+// close succession (e.g. cameras list populates and selection is set in the
+// same tick) and overlapping getUserMedia calls fight for the same ISP.
+let singleCameraChain = Promise.resolve();
+
+const tryGetUserMedia = async (deviceId) => {
+  // Prefer `exact` so Android Chrome actually switches to the requested
+  // camera rather than treating the id as a soft hint.
+  const constraints = {
+    video: { ...videoConstraintsByFrameSize.default, deviceId: { exact: deviceId } },
+    audio: false
+  };
+  return getUserMedia(constraints);
+};
+
+const loadUserMediaForSingleCamera = (dispatch, deviceId, videoTracksMapRef) => {
+  const run = async () => {
+    // Stop every previously-held camera track before opening a new one.
+    // Read from the ref at execution time so queued calls see the latest map.
+    const currentMap = videoTracksMapRef.current || {};
+    Object.values(currentMap).forEach((t) => { if (t && typeof t.stop === 'function') t.stop(); });
+
+    // Clear references so the preview <video> detaches its srcObject. iOS
+    // Safari and Android Chrome both keep the camera hardware pinned until
+    // the video element picks up the null srcObject. We deliberately do NOT
+    // dispatch SET_PUBLISH_VIDEO_TRACK here — PublishVideoDropdown reacts to
+    // the empty videoTracksMap and dispatches `videoTrack: undefined`, which
+    // replaceVideoTrack handles as a no-op. Dispatching `{}` would trip the
+    // addTrack(...) crash while publishing.
+    dispatch({type:MediaActions.SET_MEDIA_TRACKS,videoTracksMap:{}});
+    dispatch({type:MediaActions.SET_MEDIA_STREAM,stream:null});
+
+    // Wait two animation frames so React commits the clears and the browser
+    // releases the capture session before we request the next camera.
+    await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+
+    let newVideoTracksMap = {};
+    if (!deviceId) {
+      dispatch({type:MediaActions.SET_MEDIA_TRACKS,videoTracksMap:newVideoTracksMap});
+      return;
+    }
+
+    try {
+      let stream;
+      try {
+        stream = await tryGetUserMedia(deviceId);
+      } catch (e) {
+        // Android camera HAL can take a few hundred ms to release the previous
+        // session. rAF isn't always long enough, so retry once after a delay.
+        if (e && e.name === 'NotReadableError') {
+          await new Promise((resolve) => setTimeout(resolve, 400));
+          stream = await tryGetUserMedia(deviceId);
+        } else {
+          throw e;
+        }
+      }
+      const videoTracks = stream.getVideoTracks();
+      if (videoTracks.length > 0) {
+        newVideoTracksMap[deviceId] = videoTracks[0];
+      }
+    } catch (e) {
+      console.error("Loading camera had error", e);
+    }
+    dispatch({type:MediaActions.SET_MEDIA_TRACKS,videoTracksMap:newVideoTracksMap});
+  };
+
+  singleCameraChain = singleCameraChain.then(run, run);
+  return singleCameraChain;
 }
 
 const onScreenShareEnded = (dispatch) => {
@@ -92,17 +170,29 @@ const CompositorUserMedia = () => {
   const { videoTrack1DeviceId : compositeVideoTrack1DeviceId } = useSelector((state) => state.compositeSettings);
   const videoTracksMapRef = useRef(videoTracksMap);
   const audioTracksMapRef = useRef(audioTracksMap);
+  videoTracksMapRef.current = videoTracksMap;
+  audioTracksMapRef.current = audioTracksMap;
 
   // get permissions on page load
   useEffect(() => {
     getPermissions(dispatch);
   }, [dispatch]);
 
-  // get video track for each camera
+  // get video tracks for cameras. On desktop we eagerly open every camera so
+  // consumers can preview/switch instantly. On mobile the hardware only allows
+  // one camera open at a time, so we acquire just the currently-selected one
+  // and stop it before opening another.
   useEffect(() => {
-    if (gotPermissions)
+    if (!gotPermissions) return;
+    if (isMobile()) {
+      let desired = publishVideoTrack1DeviceId;
+      if (!desired || desired === 'screen') desired = compositeVideoTrack1DeviceId;
+      if (!desired || desired === 'screen') desired = cameras[0] != null ? cameras[0].deviceId : '';
+      loadUserMediaForSingleCamera(dispatch, desired, videoTracksMapRef);
+    } else {
       loadUserMediaForCameras(dispatch, cameras, videoTracksMapRef.current);
-  }, [dispatch,gotPermissions,cameras]);
+    }
+  }, [dispatch,gotPermissions,cameras,publishVideoTrack1DeviceId,compositeVideoTrack1DeviceId]);
 
   // get audio track for each microphone
   useEffect(() => {

--- a/v2/src/react-example/src/components/publish/PublishVideoElement.js
+++ b/v2/src/react-example/src/components/publish/PublishVideoElement.js
@@ -8,11 +8,15 @@ const PublishVideoElement = () => {
   const videoElement = useRef();
   const { stream } = useSelector ((state) => state.media);
 
-  // Set srcObject on the videoElement every time the stream changes
+  // Set srcObject on the videoElement every time the stream changes. We must
+  // also clear it when the stream is null — iOS Safari keeps the camera
+  // hardware pinned until the <video> element detaches its srcObject.
   useEffect(() => {
-    if (stream != null && videoElement.current != null)
-    {
+    if (videoElement.current == null) return;
+    if (stream != null) {
       videoElement.current.srcObject = stream;
+    } else {
+      videoElement.current.srcObject = null;
     }
   },[stream, videoElement]);
 

--- a/v2/src/react-example/src/components/publish/Publisher.js
+++ b/v2/src/react-example/src/components/publish/Publisher.js
@@ -76,13 +76,17 @@ const Publisher = () => {
 
   // Handle Mic and Cam Track Changes
   const { audioTrack, videoTrack } = useSelector ((state) => state.publishSettings);
-  const { peerConnection, audioSender, videoSender } = useSelector((state) => state.webrtcPublish);
+  const {
+    peerConnection,
+    peerConnectionAudioSender: audioSender,
+    peerConnectionVideoSender: videoSender,
+  } = useSelector((state) => state.webrtcPublish);
 
   useEffect(() => {
     if (peerConnection != null) {
       replaceAudioTrack(audioTrack, audioSender, peerConnection, {
         onSetSenders: (senders) => {
-          dispatch({type:WebRTCPublishActions.SET_WEBRTC_PUBLISH_PEERCONNECTION_VIDEO_SENDER,peerConnectionVideoSender:senders.videoSender});
+          dispatch({type:WebRTCPublishActions.SET_WEBRTC_PUBLISH_PEERCONNECTION_AUDIO_SENDER,peerConnectionAudioSender:senders.audioSender});
         }
       });
     }
@@ -93,7 +97,7 @@ const Publisher = () => {
     if (peerConnection != null) {
       replaceVideoTrack(videoTrack, videoSender, peerConnection, {
         onSetSenders: (senders) => {
-          dispatch({type:WebRTCPublishActions.SET_WEBRTC_PUBLISH_PEERCONNECTION_AUDIO_SENDER,peerConnectionAudioSender:senders.audioSender});
+          dispatch({type:WebRTCPublishActions.SET_WEBRTC_PUBLISH_PEERCONNECTION_VIDEO_SENDER,peerConnectionVideoSender:senders.videoSender});
         }
       });
     }

--- a/v2/src/react-example/src/webrtc/replaceAudioTrack.js
+++ b/v2/src/react-example/src/webrtc/replaceAudioTrack.js
@@ -1,20 +1,21 @@
 // replaceAudioTrack
 
-const replaceAudioTrack = (newAudioTrack, audioSender, peerConnection, callbacks) => 
+const replaceAudioTrack = (newAudioTrack, audioSender, peerConnection, callbacks) =>
 {
-  if (typeof newAudioTrack !== 'undefined')
-  {
-    if (audioSender == null)
-    {
-      let newAudioSender = peerConnection.addTrack(newAudioTrack);
-      if (callbacks.onSetSenders)
-        callbacks.onSetSenders({audioSender:newAudioSender});
-    }
-    else
-    {
-      audioSender.replaceTrack(newAudioTrack);
-    }
-  }
+  if (newAudioTrack === undefined) return;
+  // Accept null (to remove the current track) or a real MediaStreamTrack.
+  if (newAudioTrack !== null && typeof newAudioTrack.kind !== 'string') return;
 
+  if (audioSender == null)
+  {
+    if (newAudioTrack === null) return;
+    let newAudioSender = peerConnection.addTrack(newAudioTrack);
+    if (callbacks.onSetSenders)
+      callbacks.onSetSenders({audioSender:newAudioSender});
+  }
+  else
+  {
+    audioSender.replaceTrack(newAudioTrack);
+  }
 }
 export default replaceAudioTrack;

--- a/v2/src/react-example/src/webrtc/replaceVideoTrack.js
+++ b/v2/src/react-example/src/webrtc/replaceVideoTrack.js
@@ -1,21 +1,23 @@
 // replaceVideoTrack
 
-const replaceVideoTrack = (newVideoTrack, videoSender, peerConnection, callbacks) => 
+const replaceVideoTrack = (newVideoTrack, videoSender, peerConnection, callbacks) =>
 {
-  console.log(newVideoTrack);
-  if (typeof newVideoTrack !== 'undefined')
-  {
-    if (videoSender == null)
-    {
-      let newVideoSender = peerConnection.addTrack(newVideoTrack);
-      if (callbacks.onSetSenders)
-        callbacks.onSetSenders({videoSender:newVideoSender});
-    }
-    else
-    {
-      videoSender.replaceTrack(newVideoTrack);
-    }
-  }
+  if (newVideoTrack === undefined) return;
+  // Accept null (to remove the current track) or a real MediaStreamTrack.
+  // Anything else (e.g. the `{}` initial state) is a no-op — guards against
+  // RTCPeerConnection.addTrack throwing on non-track values.
+  if (newVideoTrack !== null && typeof newVideoTrack.kind !== 'string') return;
 
+  if (videoSender == null)
+  {
+    if (newVideoTrack === null) return;
+    let newVideoSender = peerConnection.addTrack(newVideoTrack);
+    if (callbacks.onSetSenders)
+      callbacks.onSetSenders({videoSender:newVideoSender});
+  }
+  else
+  {
+    videoSender.replaceTrack(newVideoTrack);
+  }
 }
 export default replaceVideoTrack;


### PR DESCRIPTION
### Description
The media-acquisition code was written for desktop, where cameras are independent devices. Mobile browsers are different in three ways that the code didn't handle:

One camera at a time. iOS/Android share a single ISP, so only one capture session can be live.
`<video srcObject>` pins the hardware. The camera isn't released until the element detaches, track.stop() alone isn't enough.
HAL release is async. Android can take 100–400 ms to free the camera after stop.
All the mobile symptoms (NotReadableError, back camera failing, preview freezing) traced back to the acquisition path ignoring these constraints.

### Changes made
In CompositorUserMedia.js, a new mobile-only path:
- Stops the probe tracks from the initial permission check.
- Acquires only the currently-selected camera (not all of them).
- Before each switch: stops the old track, dispatches stream: null + empty videoTracksMap, waits a double requestAnimationFrame so React actually commits the clear, then calls getUserMedia with deviceId: { exact } and retries once after 400 ms on NotReadableError.
- Serializes concurrent calls via a module-level promise chain so overlapping effect fires don't race the ISP.
- In PublishVideoElement.js, the `<video>` effect now clears srcObject when stream is null, without this dispatching a null stream had no visible effect on the DOM and the camera stayed pinned.

### Other bugs exposed during testing that were also solved:
Exercising the mobile switch flow surfaced bugs in the publisher that also needed fixing:

Publisher.js had 
  - (a) the onSetSenders dispatches swapped between the audio and video effects, and 
  - (b) the useSelector destructure reading audioSender/videoSender when the reducer keys are peerConnectionAudioSender/peerConnectionVideoSender. Together, the senders were never observed by the track-replacement effects. On any camera/mic change, replaceVideoTrack fell through to addTrack, creating a new transceiver each time (SDP grew BUNDLE 0 1 → 0 1 2 → …), which froze subscribers.

replaceVideoTrack.js / replaceAudioTrack.js only guarded typeof !== 'undefined', so a non-track object like {} (the reducer's initial state) would reach peerConnection.addTrack(...) and crash with a TypeError. Tightened to accept only null (to clear) or a real MediaStreamTrack.

### Testing

These changes were tested and validated to work on:
- Android device, Chrome Mobile
- iOS device, Safari
- Desktop Ubuntu, both Firefox and Chrome 