### PR TITLE
ENG-4111: Use HashRouter for v2 React examples

### DIFF
--- a/v2/src/react-example/.gitignore
+++ b/v2/src/react-example/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+build/

--- a/v2/src/react-example/src/App.js
+++ b/v2/src/react-example/src/App.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-  BrowserRouter as Router,
+  HashRouter as Router,
   Switch,
   Route,
   Redirect
@@ -32,7 +32,7 @@ const App = () => {
     <StoreProvider store={store}>
       <CompositorUserMedia />
       <Devices />
-      <Router basename={process.env.REACT_APP_BASENAME}>
+      <Router>
         <div className="container-fluid">
           <Nav buildComponent={ buildComponent }/>
           <Errors />

--- a/v2/src/react-example/src/components/shell/Nav.js
+++ b/v2/src/react-example/src/components/shell/Nav.js
@@ -1,5 +1,5 @@
 import React from 'react';
-// import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import wowzaLogo from '../../images/wowza-logo.svg'
 
 const Nav = (props) => {
@@ -28,15 +28,15 @@ const Nav = (props) => {
         { props.buildComponent === 'develop' && (
           <>
             <li className="nav-item page">
-              <a href="/publish">
+              <Link to="/publish">
                 Publish
-              </a>
+              </Link>
               <span></span>
             </li>
             <li className="nav-item page">
-              <a href="/play">
+              <Link to="/play">
                 Play
-              </a>
+              </Link>
               <span></span>
             </li>
             {/* <li className="nav-item page">


### PR DESCRIPTION
In order to be able to deploy the V2 React examples we need to change from BrowserRouter to HashRouter to simplify the deploy and keep the routing functionality.