### PR TITLE
ENG-4120: Fix icon image access in hosted webrtc example pages

### DIFF
--- a/v1/src/jquery-example/dev-view-chat.html
+++ b/v1/src/jquery-example/dev-view-chat.html
@@ -111,8 +111,8 @@
                   </div>
                   <div class="col-2">
                     <button id="camera-toggle" class="control-button">
-                      <img alt="" class="noll" id="video-off" src="./images/videocam-32px.svg" />
-                      <img alt="" class="noll" id="video-on" src="./images/videocam-off-32px.svg" style="display:none;"/>
+                      <svg class="noll" id="video-off" width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M22.6667 14V9.33333C22.6667 8.6 22.0667 8 21.3333 8H5.33333C4.6 8 4 8.6 4 9.33333V22.6667C4 23.4 4.6 24 5.33333 24H21.3333C22.0667 24 22.6667 23.4 22.6667 22.6667V18L28 23.3333V8.66667L22.6667 14Z" fill="#FF8400"/></svg>
+                      <svg class="noll" id="video-on" width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" style="display:none;"><path d="M28.0003 8.6665L22.667 13.9998V9.33317C22.667 8.59984 22.067 7.99984 21.3337 7.99984H13.0937L28.0003 22.9065V8.6665ZM4.36033 2.6665L2.66699 4.35984L6.30699 7.99984H5.33366C4.60033 7.99984 4.00033 8.59984 4.00033 9.33317V22.6665C4.00033 23.3998 4.60033 23.9998 5.33366 23.9998H21.3337C21.6137 23.9998 21.8537 23.8932 22.0537 23.7598L26.307 27.9998L28.0003 26.3065L4.36033 2.6665Z" fill="#FF8400"/></svg>
                     </button>
                   </div>
                 </div>
@@ -128,8 +128,8 @@
                   </div>
                   <div class="col-2">
                     <button id="mute-toggle" class="control-button">
-                      <img alt="" class="noll" id="mute-off" src="./images/mic-32px.svg" />
-                      <img alt="" class="noll" id="mute-on" src="./images/mic-off-32px.svg" style="display:none;"/>
+                      <svg class="noll" id="mute-off" width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M16.0003 18.6665C18.2137 18.6665 19.987 16.8798 19.987 14.6665L20.0003 6.6665C20.0003 4.45317 18.2137 2.6665 16.0003 2.6665C13.787 2.6665 12.0003 4.45317 12.0003 6.6665V14.6665C12.0003 16.8798 13.787 18.6665 16.0003 18.6665ZM23.067 14.6665C23.067 18.6665 19.6803 21.4665 16.0003 21.4665C12.3203 21.4665 8.93366 18.6665 8.93366 14.6665H6.66699C6.66699 19.2132 10.2937 22.9732 14.667 23.6265V27.9998H17.3337V23.6265C21.707 22.9865 25.3337 19.2265 25.3337 14.6665H23.067Z" fill="#FF8400"/></svg>
+                      <svg class="noll" id="mute-on" width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" style="display:none;"><path d="M25.3333 14.667H23.0667C23.0667 15.6537 22.8533 16.5737 22.4933 17.4003L24.1333 19.0403C24.88 17.7337 25.3333 16.2537 25.3333 14.667ZM19.9733 14.8937C19.9733 14.8137 20 14.747 20 14.667V6.66699C20 4.45366 18.2133 2.66699 16 2.66699C13.7867 2.66699 12 4.45366 12 6.66699V6.90699L19.9733 14.8937ZM5.69333 4.00033L4 5.69366L12.0133 13.707V14.667C12.0133 16.8803 13.7867 18.667 16 18.667C16.2933 18.667 16.5867 18.627 16.8667 18.5603L19.08 20.7737C18.1333 21.2137 17.08 21.467 16 21.467C12.32 21.467 8.93333 18.667 8.93333 14.667H6.66667C6.66667 19.2137 10.2933 22.9737 14.6667 23.627V28.0003H17.3333V23.627C18.5467 23.4537 19.6933 23.027 20.72 22.427L26.3067 28.0003L28 26.307L5.69333 4.00033Z" fill="#FF8400"/></svg>
                     </button>
                   </div>
                 </div>
@@ -139,7 +139,7 @@
                   </div>
                   <div class="col-2">
                     <button id="publish-share-link" type="button" class="control-button mt-0">
-                      <img alt="" class="noll" id="mute-off" src="./images/file_copy-24px.svg" />
+                      <svg class="noll" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M16 1H4C2.9 1 2 1.9 2 3V17H4V3H16V1ZM15 5L21 11V21C21 22.1 20.1 23 19 23H7.99C6.89 23 6 22.1 6 21L6.01 7C6.01 5.9 6.9 5 8 5H15ZM14 12H19.5L14 6.5V12Z" fill="#B2B3B5"/></svg>
                     </button>
                   </div>
                 </div>

--- a/v1/src/jquery-example/dev-view-play.html
+++ b/v1/src/jquery-example/dev-view-play.html
@@ -164,7 +164,7 @@
                   </div>
                   <div class="col-2">
                     <button id="play-share-link" type="button" class="control-button mt-0">
-                      <img alt="" class="noll" id="mute-off" src="./images/file_copy-24px.svg" />
+                      <svg class="noll" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M16 1H4C2.9 1 2 1.9 2 3V17H4V3H16V1ZM15 5L21 11V21C21 22.1 20.1 23 19 23H7.99C6.89 23 6 22.1 6 21L6.01 7C6.01 5.9 6.9 5 8 5H15ZM14 12H19.5L14 6.5V12Z" fill="#B2B3B5"/></svg>
                     </button>
                   </div>
                 </div>

--- a/v1/src/jquery-example/dev-view-publish.html
+++ b/v1/src/jquery-example/dev-view-publish.html
@@ -193,8 +193,8 @@
                   </div>
                   <div class="col-2">
                     <button id="camera-toggle" class="control-button">
-                      <img alt="" class="noll" id="video-off" src="./images/videocam-32px.svg" />
-                      <img alt="" class="noll" id="video-on" src="./images/videocam-off-32px.svg" style="display:none;"/>
+                      <svg class="noll" id="video-off" width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M22.6667 14V9.33333C22.6667 8.6 22.0667 8 21.3333 8H5.33333C4.6 8 4 8.6 4 9.33333V22.6667C4 23.4 4.6 24 5.33333 24H21.3333C22.0667 24 22.6667 23.4 22.6667 22.6667V18L28 23.3333V8.66667L22.6667 14Z" fill="#FF8400"/></svg>
+                      <svg class="noll" id="video-on" width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" style="display:none;"><path d="M28.0003 8.6665L22.667 13.9998V9.33317C22.667 8.59984 22.067 7.99984 21.3337 7.99984H13.0937L28.0003 22.9065V8.6665ZM4.36033 2.6665L2.66699 4.35984L6.30699 7.99984H5.33366C4.60033 7.99984 4.00033 8.59984 4.00033 9.33317V22.6665C4.00033 23.3998 4.60033 23.9998 5.33366 23.9998H21.3337C21.6137 23.9998 21.8537 23.8932 22.0537 23.7598L26.307 27.9998L28.0003 26.3065L4.36033 2.6665Z" fill="#FF8400"/></svg>
                     </button>
                   </div>
                 </div>
@@ -210,8 +210,8 @@
                   </div>
                   <div class="col-2">
                     <button id="mute-toggle" class="control-button">
-                      <img alt="" class="noll" id="mute-off" src="./images/mic-32px.svg" />
-                      <img alt="" class="noll" id="mute-on" src="./images/mic-off-32px.svg" style="display:none;"/>
+                      <svg class="noll" id="mute-off" width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M16.0003 18.6665C18.2137 18.6665 19.987 16.8798 19.987 14.6665L20.0003 6.6665C20.0003 4.45317 18.2137 2.6665 16.0003 2.6665C13.787 2.6665 12.0003 4.45317 12.0003 6.6665V14.6665C12.0003 16.8798 13.787 18.6665 16.0003 18.6665ZM23.067 14.6665C23.067 18.6665 19.6803 21.4665 16.0003 21.4665C12.3203 21.4665 8.93366 18.6665 8.93366 14.6665H6.66699C6.66699 19.2132 10.2937 22.9732 14.667 23.6265V27.9998H17.3337V23.6265C21.707 22.9865 25.3337 19.2265 25.3337 14.6665H23.067Z" fill="#FF8400"/></svg>
+                      <svg class="noll" id="mute-on" width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" style="display:none;"><path d="M25.3333 14.667H23.0667C23.0667 15.6537 22.8533 16.5737 22.4933 17.4003L24.1333 19.0403C24.88 17.7337 25.3333 16.2537 25.3333 14.667ZM19.9733 14.8937C19.9733 14.8137 20 14.747 20 14.667V6.66699C20 4.45366 18.2133 2.66699 16 2.66699C13.7867 2.66699 12 4.45366 12 6.66699V6.90699L19.9733 14.8937ZM5.69333 4.00033L4 5.69366L12.0133 13.707V14.667C12.0133 16.8803 13.7867 18.667 16 18.667C16.2933 18.667 16.5867 18.627 16.8667 18.5603L19.08 20.7737C18.1333 21.2137 17.08 21.467 16 21.467C12.32 21.467 8.93333 18.667 8.93333 14.667H6.66667C6.66667 19.2137 10.2933 22.9737 14.6667 23.627V28.0003H17.3333V23.627C18.5467 23.4537 19.6933 23.027 20.72 22.427L26.3067 28.0003L28 26.307L5.69333 4.00033Z" fill="#FF8400"/></svg>
                     </button>
                   </div>
                 </div>
@@ -221,7 +221,7 @@
                   </div>
                   <div class="col-2">
                     <button id="publish-share-link" type="button" class="control-button mt-0">
-                      <img alt="" class="noll" id="mute-off" src="./images/file_copy-24px.svg" />
+                      <svg class="noll" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M16 1H4C2.9 1 2 1.9 2 3V17H4V3H16V1ZM15 5L21 11V21C21 22.1 20.1 23 19 23H7.99C6.89 23 6 22.1 6 21L6.01 7C6.01 5.9 6.9 5 8 5H15ZM14 12H19.5L14 6.5V12Z" fill="#B2B3B5"/></svg>
                     </button>
                   </div>
                 </div>

--- a/v1/src/react-example/src/components/publish/PublishSettingsForm.js
+++ b/v1/src/react-example/src/components/publish/PublishSettingsForm.js
@@ -5,6 +5,11 @@ import * as PublishSettingsActions from '../../actions/publishSettingsActions';
 import * as PublishOptions from '../../constants/PublishOptions';
 import PublishAudioDropdown from './PublishAudioDropdown';
 import PublishVideoDropdown from './PublishVideoDropdown';
+import videoOnImage from '../../images/videocam-32px.svg';
+import videoOffImage from '../../images/videocam-off-32px.svg';
+import micOnImage from '../../images/mic-32px.svg';
+import micOffImage from '../../images/mic-off-32px.svg';
+import fileCopyImage from '../../images/file_copy-24px.svg';
 
 const PublishSettingsForm = () => {
 
@@ -130,8 +135,8 @@ const PublishSettingsForm = () => {
           </div>
           <div className="col-2">
             <button id="camera-toggle" className="control-button">
-              <img alt="" className="noll" id="video-off" src="/images/videocam-32px.svg" />
-              <img alt="" className="noll" id="video-on" src="/images/videocam-off-32px.svg" />
+              <img alt="" className="noll" id="video-off" src={videoOffImage} />
+              <img alt="" className="noll" id="video-on" src={videoOnImage} />
             </button>
           </div>
         </div>
@@ -141,8 +146,8 @@ const PublishSettingsForm = () => {
           </div>
           <div className="col-2">
             <button id="mute-toggle" className="control-button">
-              <img alt="" className="noll" id="mute-off" src="/images/mic-32px.svg" />
-              <img alt="" className="noll" id="mute-on" src="/images/mic-off-32px.svg" />
+              <img alt="" className="noll" id="mute-off" src={micOnImage} />
+              <img alt="" className="noll" id="mute-on" src={micOffImage} />
             </button>
           </div>
         </div>
@@ -162,7 +167,7 @@ const PublishSettingsForm = () => {
           </div>
           <div className="col-2">
             <button id="publish-share-link" type="button" className="control-button mt-0">
-              <img alt="" className="noll" id="mute-off" src="/images/file_copy-24px.svg" />
+              <img alt="" className="noll" id="mute-off" src={fileCopyImage}/>
             </button>
           </div>
         </div>

--- a/v2/src/react-example/src/components/play/PlaySettingsForm.js
+++ b/v2/src/react-example/src/components/play/PlaySettingsForm.js
@@ -9,6 +9,7 @@ import { getCookieValues } from '../../utils/CookieUtils';
 import CookieName from '../../constants/CookieName';
 import { isValidStunUrl, isValidTurnUrl, STUN_SERVER_PLACEHOLDER, TURN_SERVER_PLACEHOLDER } from '../../utils/IceServersUtils';
 import ExternalLinks from '../../constants/ExternalLinks';
+import fileCopyImage from '../../images/file_copy-24px.svg';
 
 const playUrlParametersMap = {
   signalingURL: "playSignalingURL",
@@ -435,7 +436,7 @@ const PlaySettingsForm = () => {
               onClick={handleShareLink}
               title="Copy share link"
             >
-              <img alt="Copy Link" className="noll" src="./images/file_copy-24px.svg" />
+              <img alt="Copy Link" className="noll" src={fileCopyImage} />
             </button>
           </div>
         </div>

--- a/v2/src/react-example/src/components/publish/PublishSettingsForm.js
+++ b/v2/src/react-example/src/components/publish/PublishSettingsForm.js
@@ -11,6 +11,11 @@ import { getCookieValues } from '../../utils/CookieUtils';
 import CookieName from '../../constants/CookieName';
 import { isValidStunUrl, isValidTurnUrl, STUN_SERVER_PLACEHOLDER, TURN_SERVER_PLACEHOLDER } from '../../utils/IceServersUtils';
 import ExternalLinks from '../../constants/ExternalLinks';
+import videoOnImage from '../../images/videocam-32px.svg';
+import videoOffImage from '../../images/videocam-off-32px.svg';
+import micOnImage from '../../images/mic-32px.svg';
+import micOffImage from '../../images/mic-off-32px.svg';
+import fileCopyImage from '../../images/file_copy-24px.svg';
 
 const publishUrlParametersMap = {
   signalingURL: "publishSignalingURL",
@@ -404,7 +409,7 @@ const PublishSettingsForm = () => {
                 alt=""
                 className="noll"
                 id={isCameraOn ? "video-off" : "video-on"}
-                src={isCameraOn ? "/images/videocam-32px.svg" : "/images/videocam-off-32px.svg"}
+                src={isCameraOn ? videoOnImage : videoOffImage}
               />
             </button>
           </div>
@@ -423,7 +428,7 @@ const PublishSettingsForm = () => {
                 alt=""
                 className="noll"
                 id={isMicOn ? "mute-on" : "mute-off"}
-                src={isMicOn ? "/images/mic-32px.svg" : "/images/mic-off-32px.svg"} />
+                src={isMicOn ? micOnImage : micOffImage} />
             </button>
           </div>
         </div>
@@ -443,7 +448,7 @@ const PublishSettingsForm = () => {
           </div>
           <div className="col-2">
             <button id="publish-share-link" type="button" className="control-button mt-0">
-              <img alt="" className="noll" id="mute-off" src="/images/file_copy-24px.svg" />
+              <img alt="" className="noll" id="mute-off" src={fileCopyImage} />
             </button>
           </div>
         </div>


### PR DESCRIPTION
> Ticket [ENG-4120](https://wowzamedia.jira.com/browse/ENG-4120)


### Changes made
- Updated v2 and v1 react pages with the same image import procedure used in the composite and meeting pages
- Updated the jquery pages to use the svg directly instead of loading it from fs via path