### PR TITLE
ENG-4123:  Add link to modern pages in legacy

### DIFF
--- a/v1/src/jquery-example/dev-view-play.html
+++ b/v1/src/jquery-example/dev-view-play.html
@@ -168,6 +168,11 @@
                     </button>
                   </div>
                 </div>
+                <div class="row">
+                  <div class="col-12 text-center">
+                      <small>Using modern WebRTC? <a href="https://www.wowza.com/developer/webrtc-v2/#/publish" target="_blank" rel="noopener noreferrer">Go here</a></small>
+                  </div>
+                </div>
               </form>
             </div>
           </div>

--- a/v1/src/jquery-example/dev-view-play.html
+++ b/v1/src/jquery-example/dev-view-play.html
@@ -170,7 +170,7 @@
                 </div>
                 <div class="row">
                   <div class="col-12 text-center">
-                      <small>Using modern WebRTC? <a href="https://www.wowza.com/developer/webrtc-v2/#/publish" target="_blank" rel="noopener noreferrer">Go here</a></small>
+                      <small>Using modern WebRTC? <a href="https://www.wowza.com/developer/webrtc-v2/dev-view-play" target="_blank" rel="noopener noreferrer">Go here</a></small>
                   </div>
                 </div>
               </form>

--- a/v1/src/jquery-example/dev-view-publish.html
+++ b/v1/src/jquery-example/dev-view-publish.html
@@ -227,7 +227,7 @@
                 </div>
                 <div class="row">
                   <div class="col-12 text-center">
-                      <small>Using modern WebRTC? <a href="https://www.wowza.com/developer/webrtc-v2/#/publish" target="_blank" rel="noopener noreferrer">Go here</a></small>
+                      <small>Using modern WebRTC? <a href="https://www.wowza.com/developer/webrtc-v2/dev-view-publish" target="_blank" rel="noopener noreferrer">Go here</a></small>
                   </div>
                 </div>
               </form>

--- a/v1/src/jquery-example/dev-view-publish.html
+++ b/v1/src/jquery-example/dev-view-publish.html
@@ -225,6 +225,11 @@
                     </button>
                   </div>
                 </div>
+                <div class="row">
+                  <div class="col-12 text-center">
+                      <small>Using modern WebRTC? <a href="https://www.wowza.com/developer/webrtc-v2/#/publish" target="_blank" rel="noopener noreferrer">Go here</a></small>
+                  </div>
+                </div>
               </form>
             </div>
           </div>

--- a/v1/src/react-example/src/components/play/PlaySettingsForm.js
+++ b/v1/src/react-example/src/components/play/PlaySettingsForm.js
@@ -6,6 +6,7 @@ import Cookies from 'js-cookie';
 import * as PlaySettingsActions from '../../actions/playSettingsActions';
 import { getCookieValues } from '../../utils/CookieUtils';
 import CookieName from '../../constants/CookieName';
+import ExternalLinks from '../../constants/ExternalLinks';
 
 const playUrlParametersMap = {
   "signalingURL":"playSignalingURL",
@@ -134,6 +135,11 @@ const PlaySettingsForm = () => {
               <img alt="" className="noll" id="mute-off" src={fileCopy} />
             </button>
           </div> */}
+        </div>
+        <div className="row mt-2">
+          <div className="col-12 text-center">
+            <small>{ExternalLinks.modernLinkText} <a href={ExternalLinks.modernPlay} target="_blank" rel="noopener noreferrer">{ExternalLinks.modernLinkLabel}</a></small>
+          </div>
         </div>
       </form>
     </div>

--- a/v1/src/react-example/src/components/publish/PublishSettingsForm.js
+++ b/v1/src/react-example/src/components/publish/PublishSettingsForm.js
@@ -11,6 +11,8 @@ import micOnImage from '../../images/mic-32px.svg';
 import micOffImage from '../../images/mic-off-32px.svg';
 import fileCopyImage from '../../images/file_copy-24px.svg';
 
+import ExternalLinks from '../../constants/ExternalLinks';
+
 const PublishSettingsForm = () => {
 
   const dispatch = useDispatch();
@@ -169,6 +171,11 @@ const PublishSettingsForm = () => {
             <button id="publish-share-link" type="button" className="control-button mt-0">
               <img alt="" className="noll" id="mute-off" src={fileCopyImage}/>
             </button>
+          </div>
+        </div>
+        <div className="row mt-2">
+          <div className="col-12 text-center">
+            <small>{ExternalLinks.modernLinkText} <a href={ExternalLinks.modernPublish} target="_blank" rel="noopener noreferrer">{ExternalLinks.modernLinkLabel}</a></small>
           </div>
         </div>
       </form>

--- a/v1/src/react-example/src/constants/ExternalLinks.js
+++ b/v1/src/react-example/src/constants/ExternalLinks.js
@@ -1,0 +1,8 @@
+const ExternalLinks = {
+  modernPublish: "https://www.wowza.com/developer/webrtc-v2/#/publish",
+  modernPlay: "https://www.wowza.com/developer/webrtc-v2/#/play",
+  modernLinkText: "Using modern WebRTC?",
+  modernLinkLabel: "Go here"
+}
+
+export default ExternalLinks;

--- a/v1/src/react-example/src/constants/ExternalLinks.js
+++ b/v1/src/react-example/src/constants/ExternalLinks.js
@@ -1,6 +1,6 @@
 const ExternalLinks = {
-  modernPublish: "https://www.wowza.com/developer/webrtc-v2/#/publish",
-  modernPlay: "https://www.wowza.com/developer/webrtc-v2/#/play",
+  modernPublish: "https://www.wowza.com/developer/webrtc-v2/dev-view-publish",
+  modernPlay: "https://www.wowza.com/developer/webrtc-v2/dev-view-play",
   modernLinkText: "Using modern WebRTC?",
   modernLinkLabel: "Go here"
 }


### PR DESCRIPTION
> Ticket https://wowzamedia.jira.com/browse/ENG-4123

### Changes made  
- Added a small text in play and publish pages for the v1 examples with links to modern pages (inferred from staging)

<details><summary>Screenshots</summary>
<p>

<img width="813" height="756" alt="image" src="https://github.com/user-attachments/assets/a389b927-fef5-47f8-85e4-f19d7f37bba6" />
<img width="813" height="756" alt="image" src="https://github.com/user-attachments/assets/eb7d45a8-3fde-4ad7-882e-9aa09bf7fb16" />
<img width="1935" height="756" alt="image" src="https://github.com/user-attachments/assets/e6f408bd-f013-4575-a0ee-d7aafa3ee8fd" />


</p>
</details> 