### PR TITLE
ENG-4197: Camera and microphone reported as in use on WebRTC playback example page

### DIFF
--- a/v2/src/react-example/src/App.js
+++ b/v2/src/react-example/src/App.js
@@ -15,8 +15,6 @@ import Composite from './components/composite/Composite';
 import Play from './components/play/Play';
 import Publish from './components/publish/Publish';
 import Meeting from './components/meeting/Meeting';
-import CompositorUserMedia from './components/media/CompositorUserMedia';
-import Devices from './components/media/Devices';
 import 'bootstrap/dist/css/bootstrap.css';
 import './App.css';
 
@@ -30,8 +28,6 @@ const App = () => {
 
   return (
     <StoreProvider store={store}>
-      <CompositorUserMedia />
-      <Devices />
       <Router>
         <div className="container-fluid">
           <Nav buildComponent={ buildComponent }/>

--- a/v2/src/react-example/src/components/composite/Composite.js
+++ b/v2/src/react-example/src/components/composite/Composite.js
@@ -5,10 +5,12 @@ import CompositePublishSettingsForm from './CompositePublishSettingsForm';
 import Compositor from './Compositor';
 import InputLayoutSettingsForm from './InputLayoutSettingsForm';
 import CompositePublisher from './CompositePublisher';
+import Devices from '../media/Devices';
 
 import './Composite.css';
 
 import adapter from 'webrtc-adapter';
+import CompositorUserMedia from '../media/CompositorUserMedia';
 
 const Composite = () => {
 
@@ -27,6 +29,8 @@ const Composite = () => {
 
   return (
     <div className="container-fluid mt-3" id="composite-content">
+      <CompositorUserMedia />
+      <Devices/>
       <div id="composite-content-inner">
         <div className="row justify-content-center">
           <div className="col-md-8 col-sm-12">

--- a/v2/src/react-example/src/components/media/CompositorUserMedia.js
+++ b/v2/src/react-example/src/components/media/CompositorUserMedia.js
@@ -14,47 +14,105 @@ import getDisplayScreen from '../../webrtc/getDisplayScreen';
 // NotReadableError on the second acquisition.
 const isMobile = () => /Android|webOS|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent);
 
-const getPermissions = async (dispatch) => {
+// ---------------------------------------------------------------------------
+// Centralized device-track management
+//
+// All getUserMedia / getDisplayMedia access funnels through here so media tracks
+// have exactly one owner. Two invariants keep device handles (and the OS
+// "in use" indicator) from leaking:
+//
+//   1. SINGLE QUEUE. Every operation that opens or closes a device runs through
+//      `enqueue`, so two operations can never open the same device concurrently
+//      and orphan one of the resulting tracks. (Earlier versions used three
+//      independent promise chains that raced each other.)
+//
+//   2. REGISTRY-BASED RELEASE. Every track getUserMedia hands back is recorded in
+//      `openedTracks` the instant it is created. `releaseAllTracks` stops
+//      everything in that set — NOT just whatever happens to be in the redux map.
+//      So a track that was replaced or dropped from the map can never leak: it is
+//      still in the registry until explicitly stopped.
+//
+// When adding a new media source, preserve both: open it via `enqueue`,
+// `registerTrack` the result immediately, and always `stopTrack` (never a bare
+// `track.stop()`) so the registry stays in sync.
+// ---------------------------------------------------------------------------
 
+let opQueue = Promise.resolve();
+const enqueue = (op) => { opQueue = opQueue.then(op, op); return opQueue; };
+
+// True when two track maps hold the same deviceId -> track entries. Used to avoid
+// re-dispatching an identical map: a fresh object identity would needlessly retrigger
+// every downstream effect (e.g. the stream builder), which on a camera switch fights
+// the page's own selected-track stream.
+const sameTracks = (a, b) => {
+  const ak = Object.keys(a || {});
+  const bk = Object.keys(b || {});
+  return ak.length === bk.length && ak.every((k) => a[k] === b[k]);
+};
+
+const openedTracks = new Set();
+const registerTrack = (t) => { if (t) openedTracks.add(t); };
+const stopTrack = (t) => {
+  if (t && typeof t.stop === 'function') t.stop();
+  openedTracks.delete(t);
+};
+
+// Stop every device this app has opened and clear the redux media state. Iterating
+// the registry (not the redux maps) is what makes this leak-proof.
+const releaseAllTracks = (dispatch) => {
+  openedTracks.forEach((t) => { if (t && typeof t.stop === 'function') t.stop(); });
+  openedTracks.clear();
+  dispatch({type:MediaActions.SET_MEDIA_TRACKS, videoTracksMap:{}, audioTracksMap:{}});
+  dispatch({type:MediaActions.SET_MEDIA_SCREEN_SHARE_ENDED}); // clears displayScreenTrack
+  dispatch({type:MediaActions.SET_MEDIA_STREAM, stream:null});
+};
+
+const getPermissions = (dispatch) => enqueue(async () => {
   let gotPermissions = false;
   try
   {
     const stream = await getUserMedia({video:videoConstraintsByFrameSize.default,audio:true});
-    // Release the probe tracks so they don't hold the camera on mobile.
+    // Release the probe tracks immediately so they don't hold the camera on mobile.
     stream.getTracks().forEach((t) => t.stop());
     gotPermissions = true;
   }
   catch(e) {}
   dispatch({type:MediaActions.SET_MEDIA_GOT_PERMISSIONS,gotPermissions:gotPermissions});
-}
+});
 
-const loadUserMediaForCameras  = async (dispatch, cameras, videoTracksMap) => {
-
-  let newVideoTracksMap = {...videoTracksMap};
+// On desktop we eagerly open every camera so consumers can preview/switch instantly.
+const loadUserMediaForCameras = (dispatch, cameras, videoTracksMapRef, mountedRef) => enqueue(async () => {
+  let newVideoTracksMap = {...(videoTracksMapRef.current || {})};
   for (let i = 0; i < cameras.length; i++)
   {
-    let constraints = { video:{...videoConstraintsByFrameSize.default}, audio:false };
-    constraints.video.deviceId = cameras[i].deviceId;
+    // Reuse a camera we already hold so we don't open (and orphan) a second track.
+    let existing = newVideoTracksMap[cameras[i].deviceId];
+    if (existing && existing.readyState === 'live') continue;
+
+    // Use `exact` so the browser opens the requested camera. A bare deviceId is only
+    // a soft hint that Chrome ignores, returning the default camera for every request
+    // — which makes every preview show the same physical device.
+    let constraints = { video:{...videoConstraintsByFrameSize.default, deviceId:{ exact: cameras[i].deviceId }}, audio:false };
 
     try {
-
       let stream = await getUserMedia(constraints);
-      let videoTracks = stream.getVideoTracks();
-      if (videoTracks.length > 0) {
-        newVideoTracksMap[cameras[i].deviceId] = videoTracks[0];
-      }
-
+      let track = stream.getVideoTracks()[0];
+      if (!track) continue;
+      registerTrack(track);
+      // If we unmounted while getUserMedia was in flight, stop the fresh track now
+      // instead of keeping it — the page that needed it is already gone.
+      if (mountedRef && !mountedRef.current) { stopTrack(track); return; }
+      newVideoTracksMap[cameras[i].deviceId] = track;
     } catch (e) {
       console.error("Loading camera had error", e)
     }
   }
-  dispatch({type:MediaActions.SET_MEDIA_TRACKS,videoTracksMap:newVideoTracksMap});
-}
-
-// Serialize mobile camera switches. The effect can fire multiple times in
-// close succession (e.g. cameras list populates and selection is set in the
-// same tick) and overlapping getUserMedia calls fight for the same ISP.
-let singleCameraChain = Promise.resolve();
+  // Only dispatch when the set of tracks actually changed, so a camera switch (which
+  // re-runs this effect but reuses every live track) doesn't churn videoTracksMap.
+  if (!sameTracks(newVideoTracksMap, videoTracksMapRef.current)) {
+    dispatch({type:MediaActions.SET_MEDIA_TRACKS,videoTracksMap:newVideoTracksMap});
+  }
+});
 
 const tryGetUserMedia = async (deviceId) => {
   // Prefer `exact` so Android Chrome actually switches to the requested
@@ -66,101 +124,100 @@ const tryGetUserMedia = async (deviceId) => {
   return getUserMedia(constraints);
 };
 
-const loadUserMediaForSingleCamera = (dispatch, deviceId, videoTracksMapRef) => {
-  const run = async () => {
-    // Stop every previously-held camera track before opening a new one.
-    // Read from the ref at execution time so queued calls see the latest map.
-    const currentMap = videoTracksMapRef.current || {};
-    Object.values(currentMap).forEach((t) => { if (t && typeof t.stop === 'function') t.stop(); });
+// On mobile the hardware only allows one camera open at a time, so we stop the
+// current camera before opening the requested one.
+const loadUserMediaForSingleCamera = (dispatch, deviceId, videoTracksMapRef, mountedRef) => enqueue(async () => {
+  // Stop every previously-held camera track before opening a new one.
+  Object.values(videoTracksMapRef.current || {}).forEach((t) => stopTrack(t));
 
-    // Clear references so the preview <video> detaches its srcObject. iOS
-    // Safari and Android Chrome both keep the camera hardware pinned until
-    // the video element picks up the null srcObject. We deliberately do NOT
-    // dispatch SET_PUBLISH_VIDEO_TRACK here — PublishVideoDropdown reacts to
-    // the empty videoTracksMap and dispatches `videoTrack: undefined`, which
-    // replaceVideoTrack handles as a no-op. Dispatching `{}` would trip the
-    // addTrack(...) crash while publishing.
-    dispatch({type:MediaActions.SET_MEDIA_TRACKS,videoTracksMap:{}});
-    dispatch({type:MediaActions.SET_MEDIA_STREAM,stream:null});
+  // Clear references so the preview <video> detaches its srcObject. iOS Safari and
+  // Android Chrome both keep the camera hardware pinned until the video element
+  // picks up the null srcObject. We deliberately do NOT dispatch SET_PUBLISH_VIDEO_TRACK
+  // here — PublishVideoDropdown reacts to the empty videoTracksMap and dispatches
+  // `videoTrack: undefined`, which replaceVideoTrack handles as a no-op. Dispatching
+  // `{}` would trip the addTrack(...) crash while publishing.
+  dispatch({type:MediaActions.SET_MEDIA_TRACKS,videoTracksMap:{}});
+  dispatch({type:MediaActions.SET_MEDIA_STREAM,stream:null});
 
-    // Wait two animation frames so React commits the clears and the browser
-    // releases the capture session before we request the next camera.
-    await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+  // Wait two animation frames so React commits the clears and the browser
+  // releases the capture session before we request the next camera.
+  await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
 
-    let newVideoTracksMap = {};
-    if (!deviceId) {
-      dispatch({type:MediaActions.SET_MEDIA_TRACKS,videoTracksMap:newVideoTracksMap});
-      return;
-    }
-
-    try {
-      let stream;
-      try {
-        stream = await tryGetUserMedia(deviceId);
-      } catch (e) {
-        // Android camera HAL can take a few hundred ms to release the previous
-        // session. rAF isn't always long enough, so retry once after a delay.
-        if (e && e.name === 'NotReadableError') {
-          await new Promise((resolve) => setTimeout(resolve, 400));
-          stream = await tryGetUserMedia(deviceId);
-        } else {
-          throw e;
-        }
-      }
-      const videoTracks = stream.getVideoTracks();
-      if (videoTracks.length > 0) {
-        newVideoTracksMap[deviceId] = videoTracks[0];
-      }
-    } catch (e) {
-      console.error("Loading camera had error", e);
-    }
+  let newVideoTracksMap = {};
+  if (!deviceId) {
     dispatch({type:MediaActions.SET_MEDIA_TRACKS,videoTracksMap:newVideoTracksMap});
-  };
+    return;
+  }
 
-  singleCameraChain = singleCameraChain.then(run, run);
-  return singleCameraChain;
-}
+  try {
+    let stream;
+    try {
+      stream = await tryGetUserMedia(deviceId);
+    } catch (e) {
+      // Android camera HAL can take a few hundred ms to release the previous
+      // session. rAF isn't always long enough, so retry once after a delay.
+      if (e && e.name === 'NotReadableError') {
+        await new Promise((resolve) => setTimeout(resolve, 400));
+        stream = await tryGetUserMedia(deviceId);
+      } else {
+        throw e;
+      }
+    }
+    const track = stream.getVideoTracks()[0];
+    if (track) {
+      registerTrack(track);
+      if (mountedRef && !mountedRef.current) { stopTrack(track); return; }
+      newVideoTracksMap[deviceId] = track;
+    }
+  } catch (e) {
+    console.error("Loading camera had error", e);
+  }
+  dispatch({type:MediaActions.SET_MEDIA_TRACKS,videoTracksMap:newVideoTracksMap});
+});
 
 const onScreenShareEnded = (dispatch) => {
-  console.log('onScreenShareEnded');
   dispatch({type:PublishSettingsActions.SET_PUBLISH_VIDEO_TRACK1_DEVICEID,videoTrack1DeviceId:'none'});
   dispatch({type:MediaActions.SET_MEDIA_SCREEN_SHARE_ENDED});
 }
 
-const loadDisplayScreenTrack = async (dispatch) => {
-
-  getDisplayScreen()
-  .then( (stream) => {
-    let screenTrack = stream.getVideoTracks()[0];
-    screenTrack.onended = () => { onScreenShareEnded(dispatch); };
+const loadDisplayScreenTrack = (dispatch, mountedRef) => enqueue(async () => {
+  try {
+    const stream = await getDisplayScreen();
+    const screenTrack = stream.getVideoTracks()[0];
+    if (!screenTrack) return;
+    registerTrack(screenTrack);
+    if (mountedRef && !mountedRef.current) { stopTrack(screenTrack); return; }
+    screenTrack.onended = () => { stopTrack(screenTrack); onScreenShareEnded(dispatch); };
     dispatch({type:MediaActions.SET_MEDIA_TRACKS,displayScreenTrack:screenTrack});
-  })
-  .catch( (e) => {
+  } catch (e) {
+  }
+});
 
-  });
-}
-
-const loadUserMediaForMicrophones = async (dispatch, microphones, audioTracksMap) => {
-
-  let newAudioTracksMap = {...audioTracksMap};
+const loadUserMediaForMicrophones = (dispatch, microphones, audioTracksMapRef, mountedRef) => enqueue(async () => {
+  let newAudioTracksMap = {...(audioTracksMapRef.current || {})};
   for (let i = 0; i < microphones.length; i++)
   {
-    let constraints = { audio:{} };
-    constraints.audio.deviceId = microphones[i].deviceId;
+    // Reuse a microphone we already hold so re-runs don't orphan the previous track.
+    let existing = newAudioTracksMap[microphones[i].deviceId];
+    if (existing && existing.readyState === 'live') continue;
+
+    // `exact` for the same reason as cameras: a soft deviceId hint can be ignored.
+    let constraints = { audio:{ deviceId:{ exact: microphones[i].deviceId } } };
 
     try {
-
       let stream = await getUserMedia(constraints);
-      let audioTracks = stream.getAudioTracks();
-      if (audioTracks.length > 0) {
-        newAudioTracksMap[microphones[i].deviceId] = audioTracks[0];
-      }
-
+      let track = stream.getAudioTracks()[0];
+      if (!track) continue;
+      registerTrack(track);
+      if (mountedRef && !mountedRef.current) { stopTrack(track); return; }
+      newAudioTracksMap[microphones[i].deviceId] = track;
     } catch (e) {
     }
   }
-  dispatch({type:MediaActions.SET_MEDIA_TRACKS,audioTracksMap:newAudioTracksMap});
-}
+  if (!sameTracks(newAudioTracksMap, audioTracksMapRef.current)) {
+    dispatch({type:MediaActions.SET_MEDIA_TRACKS,audioTracksMap:newAudioTracksMap});
+  }
+});
 
 const CompositorUserMedia = () => {
 
@@ -172,6 +229,20 @@ const CompositorUserMedia = () => {
   const audioTracksMapRef = useRef(audioTracksMap);
   videoTracksMapRef.current = videoTracksMap;
   audioTracksMapRef.current = audioTracksMap;
+
+  // Tracks whether this component is still mounted. The async loaders read it after
+  // getUserMedia resolves so a load that finishes after the user has navigated away
+  // stops its track instead of leaking a live (orphaned) device.
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    // Release every device we opened when the user leaves the page that mounts this
+    // component. Registry-based release also reaps any orphan a race may have left.
+    return () => {
+      mountedRef.current = false;
+      releaseAllTracks(dispatch);
+    };
+  }, [dispatch]);
 
   // get permissions on page load
   useEffect(() => {
@@ -188,29 +259,29 @@ const CompositorUserMedia = () => {
       let desired = publishVideoTrack1DeviceId;
       if (!desired || desired === 'screen') desired = compositeVideoTrack1DeviceId;
       if (!desired || desired === 'screen') desired = cameras[0] != null ? cameras[0].deviceId : '';
-      loadUserMediaForSingleCamera(dispatch, desired, videoTracksMapRef);
+      loadUserMediaForSingleCamera(dispatch, desired, videoTracksMapRef, mountedRef);
     } else {
-      loadUserMediaForCameras(dispatch, cameras, videoTracksMapRef.current);
+      loadUserMediaForCameras(dispatch, cameras, videoTracksMapRef, mountedRef);
     }
   }, [dispatch,gotPermissions,cameras,publishVideoTrack1DeviceId,compositeVideoTrack1DeviceId]);
 
   // get audio track for each microphone
   useEffect(() => {
     if (gotPermissions)
-      loadUserMediaForMicrophones(dispatch, microphones, audioTracksMapRef.current);
+      loadUserMediaForMicrophones(dispatch, microphones, audioTracksMapRef, mountedRef);
   }, [dispatch,gotPermissions,microphones]);
 
   // start screen sharing for 'publish' example
   useEffect(() => {
     if (publishVideoTrack1DeviceId === 'screen' && displayScreenTrack == null) {
-      loadDisplayScreenTrack(dispatch);
+      loadDisplayScreenTrack(dispatch, mountedRef);
     }
   }, [dispatch,publishVideoTrack1DeviceId, displayScreenTrack])
 
   // start screen sharing for 'composite' example
   useEffect(() => {
     if (compositeVideoTrack1DeviceId === 'screen' && displayScreenTrack == null) {
-      loadDisplayScreenTrack(dispatch);
+      loadDisplayScreenTrack(dispatch, mountedRef);
     }
   }, [dispatch,compositeVideoTrack1DeviceId, displayScreenTrack])
 

--- a/v2/src/react-example/src/components/meeting/Meeting.js
+++ b/v2/src/react-example/src/components/meeting/Meeting.js
@@ -2,11 +2,15 @@ import React from 'react';
 
 import Meeter from './Meeter'
 import MeetingSettingsForm from './MeetingSettingsForm';
+import Devices from '../media/Devices';
+import CompositorUserMedia from '../media/CompositorUserMedia';
 
 const Meeting = () => {
 
   return (
     <div className="row justify-content-center">
+      <CompositorUserMedia />
+      <Devices/>
       <div className="col-md-8 col-sm-12">
         <div id="peer-video-container">
           <Meeter />

--- a/v2/src/react-example/src/components/publish/Publish.js
+++ b/v2/src/react-example/src/components/publish/Publish.js
@@ -3,12 +3,16 @@ import React from 'react';
 import PublishVideoElement from './PublishVideoElement';
 import PublishLiveIndicator from './PublishLiveIndicator';
 import PublishSettingsForm from './PublishSettingsForm';
+import CompositorUserMedia from '../media/CompositorUserMedia';
+import Devices from '../../components/media/Devices';
 import Publisher from './Publisher';
 
 const Publish = () => {
 
   return (
     <div className="container-fluid mt-3" id="publish-content">
+      <CompositorUserMedia />
+      <Devices />
       <div className="row justify-content-center">
         <div className="col-md-8 col-sm-12">
           <div id="publish-video-container">


### PR DESCRIPTION
> Ticket [ENG-4197](https://wowzamedia.jira.com/browse/ENG-4197)

Centralizes WebRTC device management in CompositorUserMedia so cameras/microphones are acquired only on the views that need them and reliably released when navigating away, fixing the "device in use" indicator persisting on the playback page. Also fixes camera/mic switching opening the wrong device.

###  Changes made
- Move acquisition into the pages that use it — CompositorUserMedia/Devices now mount on Publish, Meeting, and Composite instead of app-wide, and release devices on unmount (navigation).
- Single serialized queue for all getUserMedia operations, replacing the separate per-kind promise chains that raced each other and orphaned tracks.
- Registry-based release — every opened track is recorded and releaseAllTracks() stops the registry, not the redux map, so a replaced/dropped track can never leak (was leaving the camera light on until refresh).
- Post-unmount guard (mountedRef) — a load that resolves after navigation stops its track instead of re-holding the device.
- sameTracks guard — skip redundant videoTracksMap/audioTracksMap dispatches so a camera switch no longer retriggers the stream builder and clobbers the user's selection.
- deviceId: { exact: ... } for camera and mic acquisition — a soft deviceId hint let Chrome return the default device for every request, so all previews showed the same camera; now each opens the requested device.