### PR TITLE
ENG-4348 - Adapt WebRTC publish and playback example pages to send bearer token

### DIFF
--- a/v2/src/react-example/src/actions/playSettingsActions.js
+++ b/v2/src/react-example/src/actions/playSettingsActions.js
@@ -12,6 +12,7 @@ export const SET_PLAY_IS_IP = 'SET_PLAY_IS_IP';
 export const SET_PLAY_IP = 'SET_PLAY_IP';
 export const SET_PLAY_FLAGS='SET_PLAY_FLAGS';
 export const SET_PLAY_USE_WHEP = 'SET_PLAY_USE_WHEP';
+export const SET_PLAY_AUTH_TOKEN = 'SET_PLAY_AUTH_TOKEN';
 
 export const startPlay = () => {
   return {

--- a/v2/src/react-example/src/actions/publishSettingsActions.js
+++ b/v2/src/react-example/src/actions/publishSettingsActions.js
@@ -17,6 +17,7 @@ export const SET_PUBLISH_FLAGS='SET_PUBLISH_FLAGS';
 export const TOGGLE_VIDEO_ENABLED='TOGGLE_VIDEO_ENABLED';
 export const TOGGLE_AUDIO_ENABLED='TOGGLE_AUDIO_ENABLED';
 export const SET_PUBLISH_USE_WHIP = 'SET_PUBLISH_USE_WHIP';
+export const SET_PUBLISH_AUTH_TOKEN = 'SET_PUBLISH_AUTH_TOKEN';
 
 export const startPublish = () => {
   return {

--- a/v2/src/react-example/src/components/play/PlaySettingsForm.js
+++ b/v2/src/react-example/src/components/play/PlaySettingsForm.js
@@ -47,7 +47,10 @@ const FormInput = ({ label, id, value, onChange, disabled, ...props }) => (
 );
 
 const FormCheckbox = ({ label, id, checked, onChange, disabled }) => (
-  <div className="form-group form-switch mt-2 ml-4">
+  <div className="form-group form-switch form-check-inline">
+    <label className="form-check-label mr-3" htmlFor={id}>
+      {label}
+    </label>
     <input
       id={id}
       name={id}
@@ -57,9 +60,6 @@ const FormCheckbox = ({ label, id, checked, onChange, disabled }) => (
       disabled={disabled}
       onChange={onChange}
     />
-    <label className="form-check-label" htmlFor={id}>
-      {label}
-    </label>
   </div>
 );
 
@@ -226,7 +226,7 @@ const PlaySettingsForm = () => {
           </div>
         </div>
 
-        <div className="row">
+        <div className="row align-items-center mb-2">
           <div className="col-5">
             <FormCheckbox
               label="Use WHEP"
@@ -238,7 +238,7 @@ const PlaySettingsForm = () => {
           </div>
           {playSettings.useWhep && (
             <div className="col-7">
-              <div className="form-group row">
+              <div className="form-group row mb-0 align-items-center">
                 <label className="col-auto col-form-label" htmlFor="playAuthToken">Auth Token</label>
                 <div className="col">
                   <input type="text"

--- a/v2/src/react-example/src/components/play/PlaySettingsForm.js
+++ b/v2/src/react-example/src/components/play/PlaySettingsForm.js
@@ -24,7 +24,8 @@ const playUrlParametersMap = {
   prefix: "playPrefix",
   isIp: "playIsIp",
   ip: "playIp",
-  useWhep: "playUseWhep"
+  useWhep: "playUseWhep",
+  authToken: "playAuthToken"
 };
 
 const SIGNALING_URL_PLACEHOLDER = "wss://[ssl-certificate-domain-name]/webrtc-session.json";
@@ -93,7 +94,8 @@ const PlaySettingsForm = () => {
           prefix: PlaySettingsActions.SET_PLAY_PREFIX,
           isIp: PlaySettingsActions.SET_PLAY_IS_IP,
           ip: PlaySettingsActions.SET_PLAY_IP,
-          useWhep: PlaySettingsActions.SET_PLAY_USE_WHEP
+          useWhep: PlaySettingsActions.SET_PLAY_USE_WHEP,
+          authToken: PlaySettingsActions.SET_PLAY_AUTH_TOKEN
         };
 
         const booleanKeys = ['isIp', 'useWhep'];
@@ -225,7 +227,7 @@ const PlaySettingsForm = () => {
         </div>
 
         <div className="row">
-          <div className="col-6">
+          <div className="col-5">
             <FormCheckbox
               label="Use WHEP"
               id="playUseWhep"
@@ -234,6 +236,24 @@ const PlaySettingsForm = () => {
               onChange={handleCheckboxChange(PlaySettingsActions.SET_PLAY_USE_WHEP, 'useWhep')}
             />
           </div>
+          {playSettings.useWhep && (
+            <div className="col-7">
+              <div className="form-group row">
+                <label className="col-auto col-form-label" htmlFor="playAuthToken">Auth Token</label>
+                <div className="col">
+                  <input type="text"
+                    className="form-control"
+                    id="playAuthToken"
+                    name="playAuthToken"
+                    maxLength={1024}
+                    value={playSettings.authToken || ''}
+                    disabled={connected}
+                    onChange={handleInputChange(PlaySettingsActions.SET_PLAY_AUTH_TOKEN, 'authToken')}
+                  />
+                </div>
+              </div>
+            </div>
+          )}
         </div>
 
         <div className="row mb-2">

--- a/v2/src/react-example/src/components/publish/PublishSettingsForm.js
+++ b/v2/src/react-example/src/components/publish/PublishSettingsForm.js
@@ -228,9 +228,9 @@ const PublishSettingsForm = () => {
           </div>
         </div>
 
-        <div className="row">
+        <div className="row align-items-center mb-2">
           <div className="col-5">
-            <div className="form-check form-switch form-check-inline mb-3">
+            <div className="form-group form-switch form-check-inline">
               <label className='form-check-label mr-3' htmlFor="publishUseWhip">
                 Use WHIP
               </label>
@@ -247,7 +247,7 @@ const PublishSettingsForm = () => {
           </div>
           {publishSettings.useWhip && (
             <div className="col-7">
-              <div className="form-group row">
+              <div className="form-group row mb-0 align-items-center">
                 <label className="col-auto col-form-label" htmlFor="publishAuthToken">Auth Token</label>
                 <div className="col">
                   <input type="text"

--- a/v2/src/react-example/src/components/publish/PublishSettingsForm.js
+++ b/v2/src/react-example/src/components/publish/PublishSettingsForm.js
@@ -25,7 +25,8 @@ const publishUrlParametersMap = {
   turnPassword: "publishTurnPassword",
   applicationName: "publishApplicationName",
   streamName: "publishStreamName",
-  useWhip: "publishUseWhip"
+  useWhip: "publishUseWhip",
+  authToken: "publishAuthToken"
 };
 
 const PublishSettingsForm = () => {
@@ -58,6 +59,7 @@ const PublishSettingsForm = () => {
       applicationName: PublishSettingsActions.SET_PUBLISH_APPLICATION_NAME,
       streamName: PublishSettingsActions.SET_PUBLISH_STREAM_NAME,
       useWhip: PublishSettingsActions.SET_PUBLISH_USE_WHIP,
+      authToken: PublishSettingsActions.SET_PUBLISH_AUTH_TOKEN,
     };
 
     Object.entries(publishUrlParametersMap).forEach(([stateKey, cookieKey]) => {
@@ -226,19 +228,41 @@ const PublishSettingsForm = () => {
           </div>
         </div>
 
-        <div className="form-check form-switch form-check-inline mb-3">
-          <label className='form-check-label mr-3' htmlFor="publishUseWhip">
-            Use WHIP
-          </label>
-          <input
-            className='form-check-input form-switch orange-checkbox'
-            type="checkbox"
-            id="publishUseWhip"
-            name="publishUseWhip"
-            checked={publishSettings.useWhip || false}
-            disabled={webrtcPublish.connected}
-            onChange={handleUseWhip(PublishSettingsActions.SET_PUBLISH_USE_WHIP, 'useWhip')}
-          />
+        <div className="row">
+          <div className="col-5">
+            <div className="form-check form-switch form-check-inline mb-3">
+              <label className='form-check-label mr-3' htmlFor="publishUseWhip">
+                Use WHIP
+              </label>
+              <input
+                className='form-check-input form-switch orange-checkbox'
+                type="checkbox"
+                id="publishUseWhip"
+                name="publishUseWhip"
+                checked={publishSettings.useWhip || false}
+                disabled={webrtcPublish.connected}
+                onChange={handleUseWhip(PublishSettingsActions.SET_PUBLISH_USE_WHIP, 'useWhip')}
+              />
+            </div>
+          </div>
+          {publishSettings.useWhip && (
+            <div className="col-7">
+              <div className="form-group row">
+                <label className="col-auto col-form-label" htmlFor="publishAuthToken">Auth Token</label>
+                <div className="col">
+                  <input type="text"
+                    className="form-control"
+                    id="publishAuthToken"
+                    name="publishAuthToken"
+                    maxLength="1024"
+                    value={publishSettings.authToken}
+                    disabled={webrtcPublish.connected}
+                    onChange={(e)=>dispatch({type:PublishSettingsActions.SET_PUBLISH_AUTH_TOKEN,authToken:e.target.value})}
+                  />
+                </div>
+              </div>
+            </div>
+          )}
         </div>
 
         <div className="row mb-2">

--- a/v2/src/react-example/src/reducers/playSettingsReducer.js
+++ b/v2/src/react-example/src/reducers/playSettingsReducer.js
@@ -18,6 +18,7 @@ const initialState = {
   playStop: false,
   playStopping: false,
   useWhep: false,
+  authToken: '',
 }
 
 const playSettingsReducer = (state = initialState, action) => {
@@ -38,6 +39,8 @@ const playSettingsReducer = (state = initialState, action) => {
       return { ...state, streamName: action.streamName };
     case PlaySettingsActions.SET_PLAY_USE_WHEP:
       return { ...state, useWhep: action.useWhep };
+    case PlaySettingsActions.SET_PLAY_AUTH_TOKEN:
+      return { ...state, authToken: action.authToken };
     case PlaySettingsActions.SET_PLAY_SECRET:
       console.log(`Secret: ${action.secret}`)
       return { ...state, secret: action.secret };

--- a/v2/src/react-example/src/reducers/publishSettingsReducer.js
+++ b/v2/src/react-example/src/reducers/publishSettingsReducer.js
@@ -18,6 +18,7 @@ const initialState = {
   videoFrameSize: 'default',
   userData: undefined,
   useWhip: false,
+  authToken: '',
   publishStart: false,
   publishStarting: false,
   publishStop: false,
@@ -61,6 +62,8 @@ const publishSettingsReducer = (state = initialState, action) => {
       return { ...state, userData:action.userData };
     case PublishSettingsActions.SET_PUBLISH_USE_WHIP:
       return { ...state, useWhip: action.useWhip };
+    case PublishSettingsActions.SET_PUBLISH_AUTH_TOKEN:
+      return { ...state, authToken: action.authToken };
     case PublishSettingsActions.SET_PUBLISH_FLAGS:
       let publishFlagsState = { ...state };
       if (action.publishStart != null) publishFlagsState.publishStart = action.publishStart;

--- a/v2/src/react-example/src/webrtc/startPlay.js
+++ b/v2/src/react-example/src/webrtc/startPlay.js
@@ -3,6 +3,9 @@ import getSecureToken from './SecureToken';
 import { validateParams } from '../utils/ValidationUtils';
 import { addIceServers } from '../utils/IceServersUtils';
 
+const getAuthHeaders = (authToken) =>
+  authToken ? { "Authorization": `Bearer ${authToken}` } : {};
+
 
 // Utilities
 
@@ -311,7 +314,7 @@ const startPlayWhep = async (playSettings, session, callbacks) => {
 
       await fetch(sessionUrl, {
         method: "PATCH",
-        headers: { "Content-Type": "application/trickle-ice-sdpfrag" },
+        headers: { "Content-Type": "application/trickle-ice-sdpfrag", ...getAuthHeaders(playSettings.authToken) },
         body: candidate
       });
     };
@@ -323,7 +326,7 @@ const startPlayWhep = async (playSettings, session, callbacks) => {
 
     const response = await fetch(whepUrl, {
       method: "POST",
-      headers: { "Content-Type": "application/sdp" },
+      headers: { "Content-Type": "application/sdp", ...getAuthHeaders(playSettings.authToken) },
       body: peerConnection.localDescription.sdp
     });
 
@@ -340,7 +343,7 @@ const startPlayWhep = async (playSettings, session, callbacks) => {
       for (const candidate of pendingCandidates) {
         await fetch(sessionUrl, {
           method: "PATCH",
-          headers: { "Content-Type": "application/trickle-ice-sdpfrag" },
+          headers: { "Content-Type": "application/trickle-ice-sdpfrag", ...getAuthHeaders(playSettings.authToken) },
           body: candidate
         });
       }

--- a/v2/src/react-example/src/webrtc/startPublish.js
+++ b/v2/src/react-example/src/webrtc/startPublish.js
@@ -3,6 +3,9 @@
 import { addIceServers } from "../utils/IceServersUtils";
 import { validateParams } from "../utils/ValidationUtils";
 
+const getAuthHeaders = (authToken) =>
+  authToken ? { "Authorization": `Bearer ${authToken}` } : {};
+
 const getStreamInfo = (publishSettings, session) => {
 
   return {
@@ -272,7 +275,7 @@ const startPublishWhip = async (publishSettings, session, callbacks) => {
 
       await fetch(sessionUrl, {
         method: "PATCH",
-        headers: { "Content-Type": "application/trickle-ice-sdpfrag" },
+        headers: { "Content-Type": "application/trickle-ice-sdpfrag", ...getAuthHeaders(publishSettings.authToken) },
         body: candidate
       });
     };
@@ -299,7 +302,7 @@ const startPublishWhip = async (publishSettings, session, callbacks) => {
 
     const response = await fetch(whipUrl, {
       method: "POST",
-      headers: { "Content-Type": "application/sdp" },
+      headers: { "Content-Type": "application/sdp", ...getAuthHeaders(publishSettings.authToken) },
       body: peerConnection.localDescription.sdp
     });
 
@@ -313,7 +316,7 @@ const startPublishWhip = async (publishSettings, session, callbacks) => {
     for (const candidate of pendingCandidates) {
       await fetch(sessionUrl, {
         method: "PATCH",
-        headers: { "Content-Type": "application/trickle-ice-sdpfrag" },
+        headers: { "Content-Type": "application/trickle-ice-sdpfrag", ...getAuthHeaders(publishSettings.authToken) },
         body: candidate
       });
     }
@@ -333,6 +336,7 @@ const startPublishWhip = async (publishSettings, session, callbacks) => {
       callbacks.onSetPeerConnection({ peerConnection });
 
     peerConnection._whipSessionUrl = sessionUrl;
+    peerConnection._whipAuthToken = publishSettings.authToken;
 
   } catch (e) {
     console.log(e.message);

--- a/v2/src/react-example/src/webrtc/stopPlay.js
+++ b/v2/src/react-example/src/webrtc/stopPlay.js
@@ -25,7 +25,8 @@ const stopPlay = (playSettings, peerConnection, websocket, callbacks) =>
 const stopPlayWhep = async (playSettings) => {
   if (playSettings._whepSessionUrl) {
     await fetch(playSettings._whepSessionUrl, {
-      method: "DELETE"
+      method: "DELETE",
+      headers: playSettings.authToken ? { "Authorization": `Bearer ${playSettings.authToken}` } : {}
     });
   }
 };

--- a/v2/src/react-example/src/webrtc/stopPublish.js
+++ b/v2/src/react-example/src/webrtc/stopPublish.js
@@ -29,7 +29,8 @@ const stopPublishWhip = async (peerConnection) => {
   try {
     if (peerConnection?._whipSessionUrl) {
       await fetch(peerConnection._whipSessionUrl, {
-        method: "DELETE"
+        method: "DELETE",
+        headers: peerConnection._whipAuthToken ? { "Authorization": `Bearer ${peerConnection._whipAuthToken}` } : {}
       });
     }
 


### PR DESCRIPTION
Adds an Auth Token field to the v2 react-example publish and play forms, shown inline next to the switch when "Use WHIP"/"Use WHEP" is toggled on. The token is sent as an Authorization: Bearer <token> header on all WHIP/WHEP requests (POST offer, trickle-ICE PATCH, teardown DELETE) and is persisted in the cookie, URL query params, and the play share link like the rest of the form fields. When the field is empty, no header is sent, so existing behavior is unchanged.

### Changes made

- Add authToken state, SET_PUBLISH_AUTH_TOKEN/SET_PLAY_AUTH_TOKEN actions, and reducer cases to the publish and play settings slices.
- Add an Auth Token input (horizontal label/field) next to the WHIP/WHEP switch in PublishSettingsForm and PlaySettingsForm, rendered only while the toggle is on.
- Register publishAuthToken/playAuthToken in the URL parameter maps so the existing effects handle cookie save, cookie/URL load, and share-link generation.
- Send the bearer header on WHIP/WHEP POST and PATCH requests in startPublish.js/startPlay.js, and on the session DELETE in stopPublish.js/stopPlay.js — the token is stashed on the peer connection as _whipAuthToken because stopPublish doesn't receive the settings object.

### How it looks

<details><summary>SCREENSHOTS</summary>
<p>

<img width="1567" height="713" alt="image" src="https://github.com/user-attachments/assets/5b15ba95-c2bd-40f2-beb3-109b075514cd" />
<img width="1567" height="713" alt="image" src="https://github.com/user-attachments/assets/b4877550-f50f-4c67-9052-ef4d76a73014" />
<img width="1567" height="713" alt="image" src="https://github.com/user-attachments/assets/60f19783-5f5b-4c64-809f-cd333947843b" />
<img width="1567" height="713" alt="image" src="https://github.com/user-attachments/assets/9d7913d4-4e77-48c1-92ba-cb7913e77a25" />


</p>
</details> 