### PR TITLE
ENG-4106: Changes for implementing and testing ICE Restart

### DIFF
--- a/v2/src/react-example/src/components/play/PlaySettingsForm.js
+++ b/v2/src/react-example/src/components/play/PlaySettingsForm.js
@@ -203,6 +203,19 @@ const PlaySettingsForm = () => {
   } 
   const handleStop = () => dispatch(PlaySettingsActions.stopPlay());
 
+  // Test aid: trigger an ICE restart on the active play peer connection. restartIce() flags the next
+  // negotiation for fresh ICE credentials and fires onnegotiationneeded, which startPlay.js re-sends as
+  // an OFFER over the existing connectionId so the engine renegotiates ICE without recreating the session.
+  const handleRestartIce = () => {
+    const pc = webrtcPlay.peerConnection;
+    if (pc && typeof pc.restartIce === 'function') {
+      console.log('[ICE restart] Calling peerConnection.restartIce() on the play connection.');
+      pc.restartIce();
+    } else {
+      console.warn('[ICE restart] No active peer connection, or restartIce() is unsupported in this browser.');
+    }
+  };
+
   if (!initialized) return null;
 
   const { connected } = webrtcPlay;
@@ -443,6 +456,19 @@ const PlaySettingsForm = () => {
             </button>
           </div>
         </div>
+        { connected && !playSettings.useWhep &&
+          <div className="row mt-2">
+            <div className="col-12">
+              <button
+                id="play-ice-restart-toggle"
+                type="button"
+                className="btn w-100"
+                onClick={handleRestartIce}
+                title="Trigger an ICE restart: renegotiates ICE (new ufrag/pwd) without recreating the play session"
+              >Restart ICE</button>
+            </div>
+          </div>
+        }
         <div className="row mt-2">
           <div className="col-12 text-center">
             <small>{ExternalLinks.legacyLinkText} <a href={ExternalLinks.legacyPlay} target="_blank" rel="noopener noreferrer">{ExternalLinks.legacyLinkLabel}</a></small>

--- a/v2/src/react-example/src/components/play/PlaySettingsForm.js
+++ b/v2/src/react-example/src/components/play/PlaySettingsForm.js
@@ -9,6 +9,7 @@ import { getCookieValues } from '../../utils/CookieUtils';
 import CookieName from '../../constants/CookieName';
 import { isValidStunUrl, isValidTurnUrl, STUN_SERVER_PLACEHOLDER, TURN_SERVER_PLACEHOLDER } from '../../utils/IceServersUtils';
 import CollapsibleSection from '../shared/CollapsibleSection';
+import { triggerIceRestart } from '../../utils/IceRestartUtils';
 import ExternalLinks from '../../constants/ExternalLinks';
 import fileCopyImage from '../../images/file_copy-24px.svg';
 
@@ -203,18 +204,8 @@ const PlaySettingsForm = () => {
   } 
   const handleStop = () => dispatch(PlaySettingsActions.stopPlay());
 
-  // Test aid: trigger an ICE restart on the active play peer connection. restartIce() flags the next
-  // negotiation for fresh ICE credentials and fires onnegotiationneeded, which startPlay.js re-sends as
-  // an OFFER over the existing connectionId so the engine renegotiates ICE without recreating the session.
-  const handleRestartIce = () => {
-    const pc = webrtcPlay.peerConnection;
-    if (pc && typeof pc.restartIce === 'function') {
-      console.log('[ICE restart] Calling peerConnection.restartIce() on the play connection.');
-      pc.restartIce();
-    } else {
-      console.warn('[ICE restart] No active peer connection, or restartIce() is unsupported in this browser.');
-    }
-  };
+  // Test aid: trigger an ICE restart on the active play peer connection. See IceRestartUtils.
+  const handleRestartIce = () => triggerIceRestart(webrtcPlay.peerConnection);
 
   if (!initialized) return null;
 

--- a/v2/src/react-example/src/components/publish/PublishSettingsForm.js
+++ b/v2/src/react-example/src/components/publish/PublishSettingsForm.js
@@ -225,6 +225,22 @@ const PublishSettingsForm = () => {
 
     dispatch(PublishSettingsActions.startPublish());
   };
+
+  // Test aid: trigger an ICE restart on the active publish peer connection.
+  // restartIce() flags the next negotiation for fresh ICE credentials and fires
+  // onnegotiationneeded, which the WebSocket publish flow (startPublish.js) already handles
+  // by re-sending an OFFER with a new ufrag/pwd over the same connectionId. The engine detects
+  // the credential change and renegotiates ICE without recreating the publish session.
+  const handleRestartIce = () => {
+    const pc = webrtcPublish.peerConnection;
+    if (pc && typeof pc.restartIce === 'function') {
+      console.log('[ICE restart] Calling peerConnection.restartIce(); a new offer with fresh ICE credentials will be sent.');
+      pc.restartIce();
+    } else {
+      console.warn('[ICE restart] No active peer connection, or restartIce() is unsupported in this browser.');
+    }
+  };
+
   if (!initialized) return null;
 
   return (
@@ -481,6 +497,19 @@ const PublishSettingsForm = () => {
             </button>
           </div>
         </div>
+        { webrtcPublish.connected && !publishSettings.useWhip &&
+          <div className="row mt-2">
+            <div className="col-12">
+              <button
+                id="ice-restart-toggle"
+                type="button"
+                className="btn w-100"
+                onClick={handleRestartIce}
+                title="Trigger an ICE restart: renegotiates ICE (new ufrag/pwd) without recreating the publish session"
+              >Restart ICE</button>
+            </div>
+          </div>
+        }
         <div className="row mt-2">
           <div className="col-12 text-center">
             <small>{ExternalLinks.legacyLinkText} <a href={ExternalLinks.legacyPublish} target="_blank" rel="noopener noreferrer">{ExternalLinks.legacyLinkLabel}</a></small>

--- a/v2/src/react-example/src/components/publish/PublishSettingsForm.js
+++ b/v2/src/react-example/src/components/publish/PublishSettingsForm.js
@@ -13,6 +13,7 @@ import { isValidStunUrl, isValidTurnUrl, STUN_SERVER_PLACEHOLDER, TURN_SERVER_PL
 import { parseSimulcastRenditions, getSimulcastRenditionsError } from '../../utils/SimulcastUtils';
 import PublishSimulcastSettings from './PublishSimulcastSettings';
 import CollapsibleSection from '../shared/CollapsibleSection';
+import { triggerIceRestart } from '../../utils/IceRestartUtils';
 import ExternalLinks from '../../constants/ExternalLinks';
 import videoOnImage from '../../images/videocam-32px.svg';
 import videoOffImage from '../../images/videocam-off-32px.svg';
@@ -226,20 +227,8 @@ const PublishSettingsForm = () => {
     dispatch(PublishSettingsActions.startPublish());
   };
 
-  // Test aid: trigger an ICE restart on the active publish peer connection.
-  // restartIce() flags the next negotiation for fresh ICE credentials and fires
-  // onnegotiationneeded, which the WebSocket publish flow (startPublish.js) already handles
-  // by re-sending an OFFER with a new ufrag/pwd over the same connectionId. The engine detects
-  // the credential change and renegotiates ICE without recreating the publish session.
-  const handleRestartIce = () => {
-    const pc = webrtcPublish.peerConnection;
-    if (pc && typeof pc.restartIce === 'function') {
-      console.log('[ICE restart] Calling peerConnection.restartIce(); a new offer with fresh ICE credentials will be sent.');
-      pc.restartIce();
-    } else {
-      console.warn('[ICE restart] No active peer connection, or restartIce() is unsupported in this browser.');
-    }
-  };
+  // Test aid: trigger an ICE restart on the active publish peer connection. See IceRestartUtils.
+  const handleRestartIce = () => triggerIceRestart(webrtcPublish.peerConnection);
 
   if (!initialized) return null;
 

--- a/v2/src/react-example/src/utils/IceRestartUtils.js
+++ b/v2/src/react-example/src/utils/IceRestartUtils.js
@@ -1,0 +1,77 @@
+// ICE restart recovery utilities, shared by the publish (startPublish.js) and play
+// (startPlay.js) flows.
+//
+// When the network path changes (NAT rebinding, interface switch, Wi-Fi/cellular handoff)
+// the ICE connection drops to "disconnected" or "failed". restartIce() flags the next
+// negotiation for fresh ICE credentials and fires onnegotiationneeded, which re-sends an
+// OFFER over the existing connection so the session recovers without being torn down and
+// re-established.
+
+const ICE_RESTART_GRACE_PERIOD_MS = 3000;
+
+// Attaches an oniceconnectionstatechange handler that requests an ICE restart when the
+// connection drops, automatically recovering the session in place.
+export const attachIceRestartRecovery = (peerConnection) => {
+  let iceRestartGraceTimer = null;
+  let iceRestartInProgress = false;
+
+  const requestIceRestart = (reason) => {
+    if (iceRestartInProgress) return; // one restart at a time; the engine rejects concurrent restarts
+    if (typeof peerConnection.restartIce !== 'function') {
+      console.warn('ICE restart needed but restartIce() is not supported in this browser.');
+      return;
+    }
+    iceRestartInProgress = true;
+    console.log(`Requesting ICE restart (${reason}).`);
+    peerConnection.restartIce();
+  };
+
+  peerConnection.oniceconnectionstatechange = () => {
+    const iceState = peerConnection.iceConnectionState;
+    console.log(`ICE connection state: ${iceState}`);
+
+    switch (iceState) {
+      case 'failed':
+        // Hard failure - recover immediately.
+        if (iceRestartGraceTimer) { clearTimeout(iceRestartGraceTimer); iceRestartGraceTimer = null; }
+        requestIceRestart('iceConnectionState=failed');
+        break;
+      case 'disconnected':
+        // Often transient - give it a moment to self-heal before forcing a restart.
+        if (!iceRestartGraceTimer && !iceRestartInProgress) {
+          iceRestartGraceTimer = setTimeout(() => {
+            iceRestartGraceTimer = null;
+            const current = peerConnection.iceConnectionState;
+            if (current === 'disconnected' || current === 'failed') {
+              requestIceRestart(`iceConnectionState=${current} after grace period`);
+            }
+          }, ICE_RESTART_GRACE_PERIOD_MS);
+        }
+        break;
+      case 'connected':
+      case 'completed':
+        // Recovered (or initial connect): clear pending work and re-arm for the next change.
+        if (iceRestartGraceTimer) { clearTimeout(iceRestartGraceTimer); iceRestartGraceTimer = null; }
+        iceRestartInProgress = false;
+        break;
+      default:
+        // 'new' / 'checking' / 'closed' - no recovery action needed; log just in case.
+        console.log(`ICE connection state ${iceState}: no ICE-restart action taken.`);
+        break;
+    }
+  };
+};
+
+// Test aid: manually trigger an ICE restart on an active peer connection. restartIce()
+// flags the next negotiation for fresh ICE credentials and fires onnegotiationneeded,
+// which the signaling flow handles by re-sending an OFFER with a new ufrag/pwd over the
+// same connectionId. The engine detects the credential change and renegotiates ICE
+// without recreating the session.
+export const triggerIceRestart = (peerConnection) => {
+  if (peerConnection && typeof peerConnection.restartIce === 'function') {
+    console.log('[ICE restart] Calling peerConnection.restartIce(); a new offer with fresh ICE credentials will be sent.');
+    peerConnection.restartIce();
+  } else {
+    console.warn('[ICE restart] No active peer connection, or restartIce() is unsupported in this browser.');
+  }
+};

--- a/v2/src/react-example/src/webrtc/startPlay.js
+++ b/v2/src/react-example/src/webrtc/startPlay.js
@@ -115,6 +115,66 @@ const websocketOnOpen = async (playSettings, websocket, callbacks, session) => {
       }
     }
 
+    peerConnection.onnegotiationneeded = () => {
+      // The initial play offer is sent explicitly below. The negotiationneeded that addTransceiver()
+      // fires runs before the server assigns a connectionId, so skip it. Once connected (a real
+      // connectionId is assigned), a negotiationneeded means restartIce() was called - re-send the offer
+      // (carrying the fresh ICE credentials restartIce() flagged) over the existing connection.
+      if (session.sessionId === '[empty]') return;
+      console.log('onnegotiationneeded: re-sending play offer for ICE restart.');
+      websocketSendPlayGetOffer(playSettings, websocket, peerConnection, callbacks, session);
+    };
+
+    // ICE restart recovery: when the network path changes the ICE connection drops to "disconnected"
+    // or "failed". restartIce() flags the next negotiation for fresh ICE credentials and fires
+    // onnegotiationneeded (above), which re-sends the offer so the session recovers in place.
+    let iceRestartGraceTimer = null;
+    let iceRestartInProgress = false;
+
+    const requestIceRestart = (reason) => {
+      if (iceRestartInProgress) return; // one restart at a time; the engine rejects concurrent restarts
+      if (typeof peerConnection.restartIce !== 'function') {
+        console.warn('ICE restart needed but restartIce() is not supported in this browser.');
+        return;
+      }
+      iceRestartInProgress = true;
+      console.log(`Requesting ICE restart (${reason}).`);
+      peerConnection.restartIce();
+    };
+
+    peerConnection.oniceconnectionstatechange = () => {
+      const iceState = peerConnection.iceConnectionState;
+      console.log(`ICE connection state: ${iceState}`);
+
+      switch (iceState) {
+        case 'failed':
+          // Hard failure - recover immediately.
+          if (iceRestartGraceTimer) { clearTimeout(iceRestartGraceTimer); iceRestartGraceTimer = null; }
+          requestIceRestart('iceConnectionState=failed');
+          break;
+        case 'disconnected':
+          // Often transient - give it a moment to self-heal before forcing a restart.
+          if (!iceRestartGraceTimer && !iceRestartInProgress) {
+            iceRestartGraceTimer = setTimeout(() => {
+              iceRestartGraceTimer = null;
+              const current = peerConnection.iceConnectionState;
+              if (current === 'disconnected' || current === 'failed') {
+                requestIceRestart(`iceConnectionState=${current} after grace period`);
+              }
+            }, 3000);
+          }
+          break;
+        case 'connected':
+        case 'completed':
+          // Recovered (or initial connect): clear pending work and re-arm for the next change.
+          if (iceRestartGraceTimer) { clearTimeout(iceRestartGraceTimer); iceRestartGraceTimer = null; }
+          iceRestartInProgress = false;
+          break;
+        default:
+          break;
+      }
+    };
+
     websocket.addEventListener("message", (event) => { websocketOnMessage(event, playSettings, peerConnection, websocket, callbacks, session, pendingCandidates); });
 
     websocketSendPlayGetOffer(playSettings, websocket, peerConnection, callbacks, session);

--- a/v2/src/react-example/src/webrtc/startPlay.js
+++ b/v2/src/react-example/src/webrtc/startPlay.js
@@ -2,6 +2,7 @@ import stopPlay from './stopPlay';
 import getSecureToken from './SecureToken';
 import { validateParams } from '../utils/ValidationUtils';
 import { addIceServers } from '../utils/IceServersUtils';
+import { attachIceRestartRecovery } from '../utils/IceRestartUtils';
 
 const getAuthHeaders = (authToken) =>
   authToken ? { "Authorization": `Bearer ${authToken}` } : {};
@@ -125,55 +126,9 @@ const websocketOnOpen = async (playSettings, websocket, callbacks, session) => {
       websocketSendPlayGetOffer(playSettings, websocket, peerConnection, callbacks, session);
     };
 
-    // ICE restart recovery: when the network path changes the ICE connection drops to "disconnected"
-    // or "failed". restartIce() flags the next negotiation for fresh ICE credentials and fires
-    // onnegotiationneeded (above), which re-sends the offer so the session recovers in place.
-    let iceRestartGraceTimer = null;
-    let iceRestartInProgress = false;
-
-    const requestIceRestart = (reason) => {
-      if (iceRestartInProgress) return; // one restart at a time; the engine rejects concurrent restarts
-      if (typeof peerConnection.restartIce !== 'function') {
-        console.warn('ICE restart needed but restartIce() is not supported in this browser.');
-        return;
-      }
-      iceRestartInProgress = true;
-      console.log(`Requesting ICE restart (${reason}).`);
-      peerConnection.restartIce();
-    };
-
-    peerConnection.oniceconnectionstatechange = () => {
-      const iceState = peerConnection.iceConnectionState;
-      console.log(`ICE connection state: ${iceState}`);
-
-      switch (iceState) {
-        case 'failed':
-          // Hard failure - recover immediately.
-          if (iceRestartGraceTimer) { clearTimeout(iceRestartGraceTimer); iceRestartGraceTimer = null; }
-          requestIceRestart('iceConnectionState=failed');
-          break;
-        case 'disconnected':
-          // Often transient - give it a moment to self-heal before forcing a restart.
-          if (!iceRestartGraceTimer && !iceRestartInProgress) {
-            iceRestartGraceTimer = setTimeout(() => {
-              iceRestartGraceTimer = null;
-              const current = peerConnection.iceConnectionState;
-              if (current === 'disconnected' || current === 'failed') {
-                requestIceRestart(`iceConnectionState=${current} after grace period`);
-              }
-            }, 3000);
-          }
-          break;
-        case 'connected':
-        case 'completed':
-          // Recovered (or initial connect): clear pending work and re-arm for the next change.
-          if (iceRestartGraceTimer) { clearTimeout(iceRestartGraceTimer); iceRestartGraceTimer = null; }
-          iceRestartInProgress = false;
-          break;
-        default:
-          break;
-      }
-    };
+    // ICE restart recovery: re-establishes the ICE connection in place when the network
+    // path changes, without tearing down the play session. See IceRestartUtils.
+    attachIceRestartRecovery(peerConnection);
 
     websocket.addEventListener("message", (event) => { websocketOnMessage(event, playSettings, peerConnection, websocket, callbacks, session, pendingCandidates); });
 

--- a/v2/src/react-example/src/webrtc/startPublish.js
+++ b/v2/src/react-example/src/webrtc/startPublish.js
@@ -164,6 +164,58 @@ const websocketOnOpen = (publishSettings, websocket, callbacks, session) => {
       }
     }
 
+    // ICE restart recovery: when the network path changes (NAT rebinding, interface
+    // switch, Wi-Fi/cellular handoff) the ICE connection drops to "disconnected" or
+    // "failed". restartIce() flags the next negotiation for fresh ICE credentials and
+    // fires onnegotiationneeded, which re-sends an OFFER over the existing connection so
+    // the session recovers without being torn down and re-established.
+    let iceRestartGraceTimer = null;
+    let iceRestartInProgress = false;
+
+    const requestIceRestart = (reason) => {
+      if (iceRestartInProgress) return; // one restart at a time; the engine rejects concurrent restarts
+      if (typeof peerConnection.restartIce !== 'function') {
+        console.warn('ICE restart needed but restartIce() is not supported in this browser.');
+        return;
+      }
+      iceRestartInProgress = true;
+      console.log(`Requesting ICE restart (${reason}).`);
+      peerConnection.restartIce();
+    };
+
+    peerConnection.oniceconnectionstatechange = () => {
+      const iceState = peerConnection.iceConnectionState;
+      console.log(`ICE connection state: ${iceState}`);
+
+      switch (iceState) {
+        case 'failed':
+          // Hard failure - recover immediately.
+          if (iceRestartGraceTimer) { clearTimeout(iceRestartGraceTimer); iceRestartGraceTimer = null; }
+          requestIceRestart('iceConnectionState=failed');
+          break;
+        case 'disconnected':
+          // Often transient - give it a moment to self-heal before forcing a restart.
+          if (!iceRestartGraceTimer && !iceRestartInProgress) {
+            iceRestartGraceTimer = setTimeout(() => {
+              iceRestartGraceTimer = null;
+              const current = peerConnection.iceConnectionState;
+              if (current === 'disconnected' || current === 'failed') {
+                requestIceRestart(`iceConnectionState=${current} after grace period`);
+              }
+            }, 3000);
+          }
+          break;
+        case 'connected':
+        case 'completed':
+          // Recovered (or initial connect): clear pending work and re-arm for the next change.
+          if (iceRestartGraceTimer) { clearTimeout(iceRestartGraceTimer); iceRestartGraceTimer = null; }
+          iceRestartInProgress = false;
+          break;
+        default:
+          break;
+      }
+    }
+
     let audioSender = undefined;
     let videoSender = undefined;
     if (publishSettings.audioTrack != null)

--- a/v2/src/react-example/src/webrtc/startPublish.js
+++ b/v2/src/react-example/src/webrtc/startPublish.js
@@ -8,6 +8,7 @@ import {
   ensureSimulcastSDP,
   simulcastAcceptedInAnswer
 } from "../utils/SimulcastUtils";
+import { attachIceRestartRecovery } from "../utils/IceRestartUtils";
 
 // Orchestration dispatcher: simulcast vs. single-track is a publish-flow
 // decision, so it lives here. The simulcast mechanics live in SimulcastUtils.
@@ -164,57 +165,9 @@ const websocketOnOpen = (publishSettings, websocket, callbacks, session) => {
       }
     }
 
-    // ICE restart recovery: when the network path changes (NAT rebinding, interface
-    // switch, Wi-Fi/cellular handoff) the ICE connection drops to "disconnected" or
-    // "failed". restartIce() flags the next negotiation for fresh ICE credentials and
-    // fires onnegotiationneeded, which re-sends an OFFER over the existing connection so
-    // the session recovers without being torn down and re-established.
-    let iceRestartGraceTimer = null;
-    let iceRestartInProgress = false;
-
-    const requestIceRestart = (reason) => {
-      if (iceRestartInProgress) return; // one restart at a time; the engine rejects concurrent restarts
-      if (typeof peerConnection.restartIce !== 'function') {
-        console.warn('ICE restart needed but restartIce() is not supported in this browser.');
-        return;
-      }
-      iceRestartInProgress = true;
-      console.log(`Requesting ICE restart (${reason}).`);
-      peerConnection.restartIce();
-    };
-
-    peerConnection.oniceconnectionstatechange = () => {
-      const iceState = peerConnection.iceConnectionState;
-      console.log(`ICE connection state: ${iceState}`);
-
-      switch (iceState) {
-        case 'failed':
-          // Hard failure - recover immediately.
-          if (iceRestartGraceTimer) { clearTimeout(iceRestartGraceTimer); iceRestartGraceTimer = null; }
-          requestIceRestart('iceConnectionState=failed');
-          break;
-        case 'disconnected':
-          // Often transient - give it a moment to self-heal before forcing a restart.
-          if (!iceRestartGraceTimer && !iceRestartInProgress) {
-            iceRestartGraceTimer = setTimeout(() => {
-              iceRestartGraceTimer = null;
-              const current = peerConnection.iceConnectionState;
-              if (current === 'disconnected' || current === 'failed') {
-                requestIceRestart(`iceConnectionState=${current} after grace period`);
-              }
-            }, 3000);
-          }
-          break;
-        case 'connected':
-        case 'completed':
-          // Recovered (or initial connect): clear pending work and re-arm for the next change.
-          if (iceRestartGraceTimer) { clearTimeout(iceRestartGraceTimer); iceRestartGraceTimer = null; }
-          iceRestartInProgress = false;
-          break;
-        default:
-          break;
-      }
-    }
+    // ICE restart recovery: re-establishes the ICE connection in place when the network
+    // path changes, without tearing down the publish session. See IceRestartUtils.
+    attachIceRestartRecovery(peerConnection);
 
     let audioSender = undefined;
     let videoSender = undefined;


### PR DESCRIPTION
Add an oniceconnectionstatechange handler to the v2 publish and play WebSocket
flows that calls restartIce() when the path drops (failed, or disconnected past
a short grace period), recovering the session across network changes without a
full reconnect. Play has no onnegotiationneeded wiring, so it re-sends the offer
over the existing connection, guarded so the initial offer isn't duplicated.
Add a manual "Restart ICE" button to both settings forms for testing.