### PR TITLE
ENG-4469: refactor ice restart message

### DIFF
--- a/v2/src/react-example/src/components/play/PlaySettingsForm.js
+++ b/v2/src/react-example/src/components/play/PlaySettingsForm.js
@@ -447,7 +447,7 @@ const PlaySettingsForm = () => {
             </button>
           </div>
         </div>
-        { connected && !playSettings.useWhep &&
+        { connected &&
           <div className="row mt-2">
             <div className="col-12">
               <button

--- a/v2/src/react-example/src/components/publish/PublishSettingsForm.js
+++ b/v2/src/react-example/src/components/publish/PublishSettingsForm.js
@@ -486,7 +486,7 @@ const PublishSettingsForm = () => {
             </button>
           </div>
         </div>
-        { webrtcPublish.connected && !publishSettings.useWhip &&
+        { webrtcPublish.connected &&
           <div className="row mt-2">
             <div className="col-12">
               <button

--- a/v2/src/react-example/src/utils/IceRestartUtils.js
+++ b/v2/src/react-example/src/utils/IceRestartUtils.js
@@ -60,6 +60,14 @@ export const attachIceRestartRecovery = (peerConnection) => {
         break;
     }
   };
+
+  // For transports that drive the restart from outside this module (WHIP/WHEP renegotiate via
+  // onnegotiationneeded): if that restart attempt fails, ICE stays failed/disconnected and no
+  // further state-change event fires, so the "one restart at a time" guard would block every
+  // retry forever. notifyRestartFailed() clears the guard so a later transition can try again.
+  return {
+    notifyRestartFailed: () => { iceRestartInProgress = false; },
+  };
 };
 
 // Test aid: manually trigger an ICE restart on an active peer connection. restartIce()

--- a/v2/src/react-example/src/utils/SdpFragUtils.js
+++ b/v2/src/react-example/src/utils/SdpFragUtils.js
@@ -1,0 +1,40 @@
+// Helpers for WHIP/WHEP ICE restart over application/trickle-ice-sdpfrag (RFC 9725).
+//
+// The browser only exposes full-SDP APIs (createOffer / setRemoteDescription), while the wire format for an
+// ICE restart is a partial SDP ("sdpfrag") carrying just the new ICE credentials and candidates. These helpers
+// bridge between the two: extract credentials from an offer, build the outgoing fragment, parse the server's
+// fragment, and splice the server's new ICE into the previously negotiated answer.
+
+export const extractIceCredentials = (sdp) => {
+  const ufrag = sdp.match(/^a=ice-ufrag:(.*)$/m);
+  const pwd = sdp.match(/^a=ice-pwd:(.*)$/m);
+  return {
+    ufrag: ufrag ? ufrag[1].trim() : null,
+    pwd: pwd ? pwd[1].trim() : null,
+  };
+};
+
+// The ICE-restart fragment a WHIP/WHEP client PATCHes: just the fresh local ICE credentials.
+export const buildIceRestartFragment = (ufrag, pwd) =>
+  `a=ice-ufrag:${ufrag}\r\na=ice-pwd:${pwd}\r\n`;
+
+export const parseIceFragment = (fragment) => {
+  const { ufrag, pwd } = extractIceCredentials(fragment);
+  const candidates = [];
+  for (const line of fragment.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    const idx = trimmed.indexOf("candidate:");
+    if (idx >= 0) candidates.push(trimmed.substring(idx)); // "candidate:..." (the form addIceCandidate expects)
+  }
+  return { ufrag, pwd, candidates };
+};
+
+// Rebuild a full answer SDP from the current one by swapping in the server's new ICE credentials and dropping
+// the stale candidates (the new ones are applied separately via addIceCandidate). setRemoteDescription needs a
+// full SDP, so we patch the previously negotiated answer in place rather than reconstructing it from scratch.
+export const applyServerIceToAnswer = (answerSdp, ufrag, pwd) =>
+  answerSdp
+    .replace(/^a=ice-ufrag:.*$/gm, `a=ice-ufrag:${ufrag}`)
+    .replace(/^a=ice-pwd:.*$/gm, `a=ice-pwd:${pwd}`)
+    .replace(/^a=candidate:.*\r?\n/gm, "")
+    .replace(/^a=end-of-candidates\r?\n/gm, "");

--- a/v2/src/react-example/src/utils/SdpFragUtils.js
+++ b/v2/src/react-example/src/utils/SdpFragUtils.js
@@ -32,9 +32,53 @@ export const parseIceFragment = (fragment) => {
 // Rebuild a full answer SDP from the current one by swapping in the server's new ICE credentials and dropping
 // the stale candidates (the new ones are applied separately via addIceCandidate). setRemoteDescription needs a
 // full SDP, so we patch the previously negotiated answer in place rather than reconstructing it from scratch.
-export const applyServerIceToAnswer = (answerSdp, ufrag, pwd) =>
-  answerSdp
-    .replace(/^a=ice-ufrag:.*$/gm, `a=ice-ufrag:${ufrag}`)
-    .replace(/^a=ice-pwd:.*$/gm, `a=ice-pwd:${pwd}`)
+export const applyServerIceToAnswer = (answerSdp, ufrag, pwd) => {
+  let sdp = answerSdp;
+  // Only swap a credential the server actually sent; otherwise we'd write the literal "null"
+  // into the SDP and corrupt the very answer we're trying to recover with.
+  if (ufrag) sdp = sdp.replace(/^a=ice-ufrag:.*$/gm, `a=ice-ufrag:${ufrag}`);
+  if (pwd) sdp = sdp.replace(/^a=ice-pwd:.*$/gm, `a=ice-pwd:${pwd}`);
+  return sdp
     .replace(/^a=candidate:.*\r?\n/gm, "")
     .replace(/^a=end-of-candidates\r?\n/gm, "");
+};
+
+// Performs a WHIP/WHEP ICE restart over the established session (RFC 9725): create an offer
+// (restartIce() must already have flagged fresh local ICE credentials), PATCH just those
+// credentials to the resource URL as an application/trickle-ice-sdpfrag, then splice the
+// server's returned ICE parameters into the active answer so media recovers in place. Throws on
+// a non-OK response or any negotiation failure so the caller can surface the error and recover.
+export const sendWhipWhepIceRestart = async (peerConnection, sessionUrl, { authHeaders = {}, label = "" } = {}) => {
+  const offer = await peerConnection.createOffer(); // restartIce() already flagged new ICE creds
+  await peerConnection.setLocalDescription(offer);
+
+  const { ufrag, pwd } = extractIceCredentials(peerConnection.localDescription.sdp);
+  const fragment = buildIceRestartFragment(ufrag, pwd);
+  console.log(`Sending ${label} ICE-restart sdpfrag:\n${fragment}`);
+
+  const restartResponse = await fetch(sessionUrl, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/trickle-ice-sdpfrag", ...authHeaders },
+    body: fragment,
+  });
+
+  if (!restartResponse.ok) {
+    throw new Error(`${label} ICE restart failed: ${restartResponse.status}`);
+  }
+
+  const answerFragment = await restartResponse.text();
+  console.log(`Received ${label} ICE-restart sdpfrag:\n${answerFragment}`);
+
+  const server = parseIceFragment(answerFragment);
+  const currentAnswer = (peerConnection.currentRemoteDescription || peerConnection.remoteDescription).sdp;
+  const patchedAnswer = applyServerIceToAnswer(currentAnswer, server.ufrag, server.pwd);
+
+  await peerConnection.setRemoteDescription({ type: "answer", sdp: patchedAnswer });
+  for (const candidate of server.candidates) {
+    try {
+      await peerConnection.addIceCandidate({ candidate, sdpMLineIndex: 0 });
+    } catch (err) {
+      console.warn("Failed to add server ICE candidate:", err);
+    }
+  }
+};

--- a/v2/src/react-example/src/webrtc/startPlay.js
+++ b/v2/src/react-example/src/webrtc/startPlay.js
@@ -3,6 +3,7 @@ import getSecureToken from './SecureToken';
 import { validateParams } from '../utils/ValidationUtils';
 import { addIceServers } from '../utils/IceServersUtils';
 import { attachIceRestartRecovery } from '../utils/IceRestartUtils';
+import { extractIceCredentials, buildIceRestartFragment, parseIceFragment, applyServerIceToAnswer } from '../utils/SdpFragUtils';
 
 const getAuthHeaders = (authToken) =>
   authToken ? { "Authorization": `Bearer ${authToken}` } : {};
@@ -296,6 +297,7 @@ const startPlay = (playSettings, callbacks) =>
 const startPlayWhep = async (playSettings, session, callbacks) => {
   let peerConnection;
   let sessionUrl;
+  let negotiationEstablished = false; // gate onnegotiationneeded so only ICE restarts (not the initial offer) re-offer
   const pendingCandidates = [];
 
   try {
@@ -316,6 +318,99 @@ const startPlayWhep = async (playSettings, session, callbacks) => {
         callbacks.onConnectionStateChange({
           connected: event.currentTarget.connectionState === "connected"
         });
+      }
+    };
+
+    // ICE restart over WHEP (RFC 9725): restartIce() flags fresh ICE credentials and fires
+    // onnegotiationneeded. We PATCH only the new credentials to the resource URL as an
+    // application/trickle-ice-sdpfrag; the engine renegotiates ICE on the existing session and returns its new
+    // ICE parameters as an sdpfrag, which we splice into the current answer so playback recovers in place.
+    const sendIceRestart = async () => {
+      if (!sessionUrl) return;
+      try {
+        const offer = await peerConnection.createOffer(); // restartIce() already flagged new ICE creds
+        await peerConnection.setLocalDescription(offer);
+
+        const { ufrag, pwd } = extractIceCredentials(peerConnection.localDescription.sdp);
+        const fragment = buildIceRestartFragment(ufrag, pwd);
+        console.log("Sending WHEP ICE-restart sdpfrag:\n" + fragment);
+
+        const restartResponse = await fetch(sessionUrl, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/trickle-ice-sdpfrag", ...getAuthHeaders(playSettings.authToken) },
+          body: fragment
+        });
+
+        if (!restartResponse.ok) {
+          throw new Error(`WHEP ICE restart failed: ${restartResponse.status}`);
+        }
+
+        const answerFragment = await restartResponse.text();
+        console.log("Received WHEP ICE-restart sdpfrag:\n" + answerFragment);
+
+        const server = parseIceFragment(answerFragment);
+        const currentAnswer = (peerConnection.currentRemoteDescription || peerConnection.remoteDescription).sdp;
+        const patchedAnswer = applyServerIceToAnswer(currentAnswer, server.ufrag, server.pwd);
+
+        await peerConnection.setRemoteDescription({ type: "answer", sdp: patchedAnswer });
+        for (const candidate of server.candidates) {
+          try {
+            await peerConnection.addIceCandidate({ candidate, sdpMLineIndex: 0 });
+          } catch (err) {
+            console.warn("Failed to add server ICE candidate:", err);
+          }
+        }
+      } catch (e) {
+        peerConnectionOnError(e, callbacks);
+      }
+    };
+
+    peerConnection.onnegotiationneeded = () => {
+      if (!negotiationEstablished) return; // the initial WHEP offer is sent manually below
+      sendIceRestart();
+    };
+
+    let iceRestartGraceTimer = null;
+    let iceRestartInProgress = false;
+
+    const requestIceRestart = (reason) => {
+      if (iceRestartInProgress) return; // one restart at a time; the engine rejects concurrent restarts
+      if (typeof peerConnection.restartIce !== "function") {
+        console.warn("ICE restart needed but restartIce() is not supported in this browser.");
+        return;
+      }
+      iceRestartInProgress = true;
+      console.log(`Requesting ICE restart (${reason}).`);
+      peerConnection.restartIce();
+    };
+
+    peerConnection.oniceconnectionstatechange = () => {
+      const iceState = peerConnection.iceConnectionState;
+      console.log(`ICE connection state: ${iceState}`);
+
+      switch (iceState) {
+        case "failed":
+          if (iceRestartGraceTimer) { clearTimeout(iceRestartGraceTimer); iceRestartGraceTimer = null; }
+          requestIceRestart("iceConnectionState=failed");
+          break;
+        case "disconnected":
+          if (!iceRestartGraceTimer && !iceRestartInProgress) {
+            iceRestartGraceTimer = setTimeout(() => {
+              iceRestartGraceTimer = null;
+              const current = peerConnection.iceConnectionState;
+              if (current === "disconnected" || current === "failed") {
+                requestIceRestart(`iceConnectionState=${current} after grace period`);
+              }
+            }, 3000);
+          }
+          break;
+        case "connected":
+        case "completed":
+          if (iceRestartGraceTimer) { clearTimeout(iceRestartGraceTimer); iceRestartGraceTimer = null; }
+          iceRestartInProgress = false;
+          break;
+        default:
+          break;
       }
     };
 
@@ -371,6 +466,8 @@ const startPlayWhep = async (playSettings, session, callbacks) => {
       type: "answer",
       sdp: answerSdp
     });
+
+    negotiationEstablished = true; // from here, onnegotiationneeded means an ICE restart
 
     if (callbacks.onSetPeerConnection)
       callbacks.onSetPeerConnection({ peerConnection });

--- a/v2/src/react-example/src/webrtc/startPlay.js
+++ b/v2/src/react-example/src/webrtc/startPlay.js
@@ -3,7 +3,7 @@ import getSecureToken from './SecureToken';
 import { validateParams } from '../utils/ValidationUtils';
 import { addIceServers } from '../utils/IceServersUtils';
 import { attachIceRestartRecovery } from '../utils/IceRestartUtils';
-import { extractIceCredentials, buildIceRestartFragment, parseIceFragment, applyServerIceToAnswer } from '../utils/SdpFragUtils';
+import { sendWhipWhepIceRestart } from '../utils/SdpFragUtils';
 
 const getAuthHeaders = (authToken) =>
   authToken ? { "Authorization": `Bearer ${authToken}` } : {};
@@ -321,97 +321,24 @@ const startPlayWhep = async (playSettings, session, callbacks) => {
       }
     };
 
-    // ICE restart over WHEP (RFC 9725): restartIce() flags fresh ICE credentials and fires
-    // onnegotiationneeded. We PATCH only the new credentials to the resource URL as an
-    // application/trickle-ice-sdpfrag; the engine renegotiates ICE on the existing session and returns its new
-    // ICE parameters as an sdpfrag, which we splice into the current answer so playback recovers in place.
-    const sendIceRestart = async () => {
-      if (!sessionUrl) return;
-      try {
-        const offer = await peerConnection.createOffer(); // restartIce() already flagged new ICE creds
-        await peerConnection.setLocalDescription(offer);
+    // Auto-recovery: when ICE drops, restartIce() flags fresh credentials and fires
+    // onnegotiationneeded (handled below). Reuses the same recovery state machine as the
+    // WebSocket path so the heuristics stay in one place.
+    const iceRestartRecovery = attachIceRestartRecovery(peerConnection);
 
-        const { ufrag, pwd } = extractIceCredentials(peerConnection.localDescription.sdp);
-        const fragment = buildIceRestartFragment(ufrag, pwd);
-        console.log("Sending WHEP ICE-restart sdpfrag:\n" + fragment);
-
-        const restartResponse = await fetch(sessionUrl, {
-          method: "PATCH",
-          headers: { "Content-Type": "application/trickle-ice-sdpfrag", ...getAuthHeaders(playSettings.authToken) },
-          body: fragment
-        });
-
-        if (!restartResponse.ok) {
-          throw new Error(`WHEP ICE restart failed: ${restartResponse.status}`);
-        }
-
-        const answerFragment = await restartResponse.text();
-        console.log("Received WHEP ICE-restart sdpfrag:\n" + answerFragment);
-
-        const server = parseIceFragment(answerFragment);
-        const currentAnswer = (peerConnection.currentRemoteDescription || peerConnection.remoteDescription).sdp;
-        const patchedAnswer = applyServerIceToAnswer(currentAnswer, server.ufrag, server.pwd);
-
-        await peerConnection.setRemoteDescription({ type: "answer", sdp: patchedAnswer });
-        for (const candidate of server.candidates) {
-          try {
-            await peerConnection.addIceCandidate({ candidate, sdpMLineIndex: 0 });
-          } catch (err) {
-            console.warn("Failed to add server ICE candidate:", err);
-          }
-        }
-      } catch (e) {
-        peerConnectionOnError(e, callbacks);
-      }
-    };
-
+    // ICE restart over WHEP (RFC 9725): on onnegotiationneeded we PATCH only the new credentials
+    // to the resource URL as an application/trickle-ice-sdpfrag; the engine renegotiates ICE on
+    // the existing session and returns its new ICE parameters as an sdpfrag, which we splice into
+    // the current answer so playback recovers in place.
     peerConnection.onnegotiationneeded = () => {
-      if (!negotiationEstablished) return; // the initial WHEP offer is sent manually below
-      sendIceRestart();
-    };
-
-    let iceRestartGraceTimer = null;
-    let iceRestartInProgress = false;
-
-    const requestIceRestart = (reason) => {
-      if (iceRestartInProgress) return; // one restart at a time; the engine rejects concurrent restarts
-      if (typeof peerConnection.restartIce !== "function") {
-        console.warn("ICE restart needed but restartIce() is not supported in this browser.");
-        return;
-      }
-      iceRestartInProgress = true;
-      console.log(`Requesting ICE restart (${reason}).`);
-      peerConnection.restartIce();
-    };
-
-    peerConnection.oniceconnectionstatechange = () => {
-      const iceState = peerConnection.iceConnectionState;
-      console.log(`ICE connection state: ${iceState}`);
-
-      switch (iceState) {
-        case "failed":
-          if (iceRestartGraceTimer) { clearTimeout(iceRestartGraceTimer); iceRestartGraceTimer = null; }
-          requestIceRestart("iceConnectionState=failed");
-          break;
-        case "disconnected":
-          if (!iceRestartGraceTimer && !iceRestartInProgress) {
-            iceRestartGraceTimer = setTimeout(() => {
-              iceRestartGraceTimer = null;
-              const current = peerConnection.iceConnectionState;
-              if (current === "disconnected" || current === "failed") {
-                requestIceRestart(`iceConnectionState=${current} after grace period`);
-              }
-            }, 3000);
-          }
-          break;
-        case "connected":
-        case "completed":
-          if (iceRestartGraceTimer) { clearTimeout(iceRestartGraceTimer); iceRestartGraceTimer = null; }
-          iceRestartInProgress = false;
-          break;
-        default:
-          break;
-      }
+      if (!negotiationEstablished || !sessionUrl) return; // the initial WHEP offer is sent manually below
+      sendWhipWhepIceRestart(peerConnection, sessionUrl, {
+        authHeaders: getAuthHeaders(playSettings.authToken),
+        label: "WHEP",
+      }).catch((e) => {
+        iceRestartRecovery.notifyRestartFailed(); // a failed restart leaves ICE down; let a later transition retry
+        peerConnectionOnError(e, callbacks);
+      });
     };
 
     peerConnection.onicecandidate = async (event) => {

--- a/v2/src/react-example/src/webrtc/startPlay.js
+++ b/v2/src/react-example/src/webrtc/startPlay.js
@@ -121,9 +121,10 @@ const websocketOnOpen = async (playSettings, websocket, callbacks, session) => {
       // The initial play offer is sent explicitly below. The negotiationneeded that addTransceiver()
       // fires runs before the server assigns a connectionId, so skip it. Once connected (a real
       // connectionId is assigned), a negotiationneeded means restartIce() was called - re-send the offer
-      // (carrying the fresh ICE credentials restartIce() flagged) over the existing connection.
+      // (carrying the fresh ICE credentials restartIce() flagged) over the existing connection as an
+      // ICE_RESTART (createOfferPayload picks the message type from session.negotiationEstablished).
       if (session.sessionId === '[empty]') return;
-      console.log('onnegotiationneeded: re-sending play offer for ICE restart.');
+      console.log('onnegotiationneeded: sending ICE_RESTART offer over the existing connection.');
       websocketSendPlayGetOffer(playSettings, websocket, peerConnection, callbacks, session);
     };
 
@@ -160,7 +161,7 @@ const websocketOnMessage = (event, playSettings, peerConnection, websocket, call
     session.repeaterRetryCount++;
 
     if (session.repeaterRetryCount < 10) {
-      setTimeout(() => { websocketSendPlayGetOffer(playSettings, websocket, peerConnection, callbacks) }, 1000);
+      setTimeout(() => { websocketSendPlayGetOffer(playSettings, websocket, peerConnection, callbacks, session) }, 1000);
     } else {
       websocketOnError({message:'Live stream repeater timeout: ' + playSettings.streamName}, callbacks);
       stopPlay(playSettings, peerConnection, websocket, callbacks);
@@ -193,6 +194,8 @@ const websocketOnMessage = (event, playSettings, peerConnection, websocket, call
         peerConnection
           .setRemoteDescription(new RTCSessionDescription(sdpData))
           .then(() => {
+            // Initial offer/answer is complete; from here a re-offer is an ICE restart.
+            session.negotiationEstablished = true;
             console.log("Remote Description Set Successfully.");
           })
           .catch((err) => peerConnectionOnError(err, callbacks));
@@ -210,8 +213,10 @@ const websocketOnError = (error, callbacks) => {
 
 const createOfferPayload = (playSettings, session, secureToken = null) => {
   const streamInfo = getStreamInfo(playSettings, session);
+  // After the initial negotiation a re-offer is an ICE restart: signal ICE_RESTART carrying the full offer
+  // SDP (the engine normalizes it to a trickle-ice-sdpfrag). A plain OFFER restart is no longer auto-detected.
   const offerPayload = {
-      messageType: "OFFER",
+      messageType: session.negotiationEstablished ? "ICE_RESTART" : "OFFER",
       action: "VIEW",
       applicationName: streamInfo.applicationName,
       streamName: streamInfo.streamName,
@@ -263,6 +268,8 @@ const startPlay = (playSettings, callbacks) =>
     const session = {
       sessionId: '[empty]',
       repeaterRetryCount: 0,
+      // false until the initial offer/answer completes; afterwards a re-offer is an ICE restart.
+      negotiationEstablished: false,
       peerConnectionConfig: {iceServers: []}
     };
 

--- a/v2/src/react-example/src/webrtc/startPublish.js
+++ b/v2/src/react-example/src/webrtc/startPublish.js
@@ -9,7 +9,7 @@ import {
   simulcastAcceptedInAnswer
 } from "../utils/SimulcastUtils";
 import { attachIceRestartRecovery } from "../utils/IceRestartUtils";
-import { extractIceCredentials, buildIceRestartFragment, parseIceFragment, applyServerIceToAnswer } from "../utils/SdpFragUtils";
+import { sendWhipWhepIceRestart } from "../utils/SdpFragUtils";
 
 // Orchestration dispatcher: simulcast vs. single-track is a publish-flow
 // decision, so it lives here. The simulcast mechanics live in SimulcastUtils.
@@ -324,97 +324,24 @@ const startPublishWhip = async (publishSettings, session, callbacks) => {
         callbacks.onConnectionStateChange({ connected });
     };
 
-    // ICE restart over WHIP (RFC 9725): restartIce() flags fresh ICE credentials and fires
-    // onnegotiationneeded. We PATCH only the new credentials to the resource URL as an
-    // application/trickle-ice-sdpfrag; the engine renegotiates ICE on the existing session and returns its new
-    // ICE parameters as an sdpfrag, which we splice into the current answer so media recovers without a teardown.
-    const sendIceRestart = async () => {
-      if (!sessionUrl) return;
-      try {
-        const offer = await peerConnection.createOffer(); // restartIce() already flagged new ICE creds
-        await peerConnection.setLocalDescription(offer);
+    // Auto-recovery: when ICE drops, restartIce() flags fresh credentials and fires
+    // onnegotiationneeded (handled below). Reuses the same recovery state machine as the
+    // WebSocket path so the heuristics stay in one place.
+    const iceRestartRecovery = attachIceRestartRecovery(peerConnection);
 
-        const { ufrag, pwd } = extractIceCredentials(peerConnection.localDescription.sdp);
-        const fragment = buildIceRestartFragment(ufrag, pwd);
-        console.log("Sending WHIP ICE-restart sdpfrag:\n" + fragment);
-
-        const restartResponse = await fetch(sessionUrl, {
-          method: "PATCH",
-          headers: { "Content-Type": "application/trickle-ice-sdpfrag", ...getAuthHeaders(publishSettings.authToken) },
-          body: fragment
-        });
-
-        if (!restartResponse.ok) {
-          throw new Error(`WHIP ICE restart failed: ${restartResponse.status}`);
-        }
-
-        const answerFragment = await restartResponse.text();
-        console.log("Received WHIP ICE-restart sdpfrag:\n" + answerFragment);
-
-        const server = parseIceFragment(answerFragment);
-        const currentAnswer = (peerConnection.currentRemoteDescription || peerConnection.remoteDescription).sdp;
-        const patchedAnswer = applyServerIceToAnswer(currentAnswer, server.ufrag, server.pwd);
-
-        await peerConnection.setRemoteDescription({ type: "answer", sdp: patchedAnswer });
-        for (const candidate of server.candidates) {
-          try {
-            await peerConnection.addIceCandidate({ candidate, sdpMLineIndex: 0 });
-          } catch (err) {
-            console.warn("Failed to add server ICE candidate:", err);
-          }
-        }
-      } catch (e) {
-        peerConnectionOnError(e, callbacks);
-      }
-    };
-
+    // ICE restart over WHIP (RFC 9725): on onnegotiationneeded we PATCH only the new credentials
+    // to the resource URL as an application/trickle-ice-sdpfrag; the engine renegotiates ICE on
+    // the existing session and returns its new ICE parameters as an sdpfrag, which we splice into
+    // the current answer so media recovers without a teardown.
     peerConnection.onnegotiationneeded = () => {
-      if (!negotiationEstablished) return; // the initial WHIP offer is sent manually below
-      sendIceRestart();
-    };
-
-    let iceRestartGraceTimer = null;
-    let iceRestartInProgress = false;
-
-    const requestIceRestart = (reason) => {
-      if (iceRestartInProgress) return; // one restart at a time; the engine rejects concurrent restarts
-      if (typeof peerConnection.restartIce !== "function") {
-        console.warn("ICE restart needed but restartIce() is not supported in this browser.");
-        return;
-      }
-      iceRestartInProgress = true;
-      console.log(`Requesting ICE restart (${reason}).`);
-      peerConnection.restartIce();
-    };
-
-    peerConnection.oniceconnectionstatechange = () => {
-      const iceState = peerConnection.iceConnectionState;
-      console.log(`ICE connection state: ${iceState}`);
-
-      switch (iceState) {
-        case "failed":
-          if (iceRestartGraceTimer) { clearTimeout(iceRestartGraceTimer); iceRestartGraceTimer = null; }
-          requestIceRestart("iceConnectionState=failed");
-          break;
-        case "disconnected":
-          if (!iceRestartGraceTimer && !iceRestartInProgress) {
-            iceRestartGraceTimer = setTimeout(() => {
-              iceRestartGraceTimer = null;
-              const current = peerConnection.iceConnectionState;
-              if (current === "disconnected" || current === "failed") {
-                requestIceRestart(`iceConnectionState=${current} after grace period`);
-              }
-            }, 3000);
-          }
-          break;
-        case "connected":
-        case "completed":
-          if (iceRestartGraceTimer) { clearTimeout(iceRestartGraceTimer); iceRestartGraceTimer = null; }
-          iceRestartInProgress = false;
-          break;
-        default:
-          break;
-      }
+      if (!negotiationEstablished || !sessionUrl) return; // the initial WHIP offer is sent manually below
+      sendWhipWhepIceRestart(peerConnection, sessionUrl, {
+        authHeaders: getAuthHeaders(publishSettings.authToken),
+        label: "WHIP",
+      }).catch((e) => {
+        iceRestartRecovery.notifyRestartFailed(); // a failed restart leaves ICE down; let a later transition retry
+        peerConnectionOnError(e, callbacks);
+      });
     };
 
     peerConnection.onicecandidate = async (event) => {

--- a/v2/src/react-example/src/webrtc/startPublish.js
+++ b/v2/src/react-example/src/webrtc/startPublish.js
@@ -72,15 +72,19 @@ const peerConnectionCreateOfferSuccess = (description, publishSettings, websocke
       const offerSdp = publishSettings.useSimulcast
         ? ensureSimulcastSDP(peerConnection.localDescription.sdp, publishSettings.simulcastRenditions)
         : peerConnection.localDescription.sdp;
+      // After the initial negotiation, a re-offer is an ICE restart and must be signaled as ICE_RESTART.
+      // The engine no longer auto-detects a restart from a plain OFFER (it would reject one); instead the
+      // full offer SDP is sent under ICE_RESTART and the engine normalizes it to a trickle-ice-sdpfrag,
+      // the same representation the WHIP/WHEP PATCH path delivers.
       const payload = {
-        messageType: "OFFER",
+        messageType: session.negotiationEstablished ? "ICE_RESTART" : "OFFER",
         action: "PUBLISH",
         sdp: offerSdp,
         applicationName: streamInfo.applicationName,
         streamName: streamInfo.streamName,
         connectionId: streamInfo.sessionId,
       };
-      console.log("Sending offer:", JSON.stringify(payload));
+      console.log(`Sending ${payload.messageType}:`, JSON.stringify(payload));
       websocket.send(JSON.stringify(payload));
     })
     .catch((error) => {
@@ -229,6 +233,8 @@ const websocketOnMessage = (event, publishSettings, websocket, peerConnection, c
       peerConnection
         .setRemoteDescription(new RTCSessionDescription(sdpData))
         .then(() => {
+          // Initial offer/answer is complete; from here any re-offer is an ICE restart.
+          session.negotiationEstablished = true;
           if (publishSettings.useSimulcast && !simulcastAcceptedInAnswer(sdpData.sdp)) {
             reportSimulcastRejection({
               callbacks, peerConnection, websocket
@@ -261,6 +267,8 @@ const startPublish = (publishSettings, websocket, callbacks) =>
     
     const session = {
         sessionId: '[empty]',
+        // false until the initial offer/answer completes; afterwards every re-offer is an ICE restart.
+        negotiationEstablished: false,
         peerConnectionConfig: {iceServers: []}
       };
 

--- a/v2/src/react-example/src/webrtc/startPublish.js
+++ b/v2/src/react-example/src/webrtc/startPublish.js
@@ -9,6 +9,7 @@ import {
   simulcastAcceptedInAnswer
 } from "../utils/SimulcastUtils";
 import { attachIceRestartRecovery } from "../utils/IceRestartUtils";
+import { extractIceCredentials, buildIceRestartFragment, parseIceFragment, applyServerIceToAnswer } from "../utils/SdpFragUtils";
 
 // Orchestration dispatcher: simulcast vs. single-track is a publish-flow
 // decision, so it lives here. The simulcast mechanics live in SimulcastUtils.
@@ -309,6 +310,7 @@ const startPublish = (publishSettings, websocket, callbacks) =>
 const startPublishWhip = async (publishSettings, session, callbacks) => {
   let peerConnection;
   let sessionUrl;
+  let negotiationEstablished = false; // gate onnegotiationneeded so only ICE restarts (not the initial offer) re-offer
   const pendingCandidates = [];
 
   try {
@@ -320,6 +322,99 @@ const startPublishWhip = async (publishSettings, session, callbacks) => {
       const connected = event.currentTarget.connectionState === "connected";
       if (callbacks.onConnectionStateChange)
         callbacks.onConnectionStateChange({ connected });
+    };
+
+    // ICE restart over WHIP (RFC 9725): restartIce() flags fresh ICE credentials and fires
+    // onnegotiationneeded. We PATCH only the new credentials to the resource URL as an
+    // application/trickle-ice-sdpfrag; the engine renegotiates ICE on the existing session and returns its new
+    // ICE parameters as an sdpfrag, which we splice into the current answer so media recovers without a teardown.
+    const sendIceRestart = async () => {
+      if (!sessionUrl) return;
+      try {
+        const offer = await peerConnection.createOffer(); // restartIce() already flagged new ICE creds
+        await peerConnection.setLocalDescription(offer);
+
+        const { ufrag, pwd } = extractIceCredentials(peerConnection.localDescription.sdp);
+        const fragment = buildIceRestartFragment(ufrag, pwd);
+        console.log("Sending WHIP ICE-restart sdpfrag:\n" + fragment);
+
+        const restartResponse = await fetch(sessionUrl, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/trickle-ice-sdpfrag", ...getAuthHeaders(publishSettings.authToken) },
+          body: fragment
+        });
+
+        if (!restartResponse.ok) {
+          throw new Error(`WHIP ICE restart failed: ${restartResponse.status}`);
+        }
+
+        const answerFragment = await restartResponse.text();
+        console.log("Received WHIP ICE-restart sdpfrag:\n" + answerFragment);
+
+        const server = parseIceFragment(answerFragment);
+        const currentAnswer = (peerConnection.currentRemoteDescription || peerConnection.remoteDescription).sdp;
+        const patchedAnswer = applyServerIceToAnswer(currentAnswer, server.ufrag, server.pwd);
+
+        await peerConnection.setRemoteDescription({ type: "answer", sdp: patchedAnswer });
+        for (const candidate of server.candidates) {
+          try {
+            await peerConnection.addIceCandidate({ candidate, sdpMLineIndex: 0 });
+          } catch (err) {
+            console.warn("Failed to add server ICE candidate:", err);
+          }
+        }
+      } catch (e) {
+        peerConnectionOnError(e, callbacks);
+      }
+    };
+
+    peerConnection.onnegotiationneeded = () => {
+      if (!negotiationEstablished) return; // the initial WHIP offer is sent manually below
+      sendIceRestart();
+    };
+
+    let iceRestartGraceTimer = null;
+    let iceRestartInProgress = false;
+
+    const requestIceRestart = (reason) => {
+      if (iceRestartInProgress) return; // one restart at a time; the engine rejects concurrent restarts
+      if (typeof peerConnection.restartIce !== "function") {
+        console.warn("ICE restart needed but restartIce() is not supported in this browser.");
+        return;
+      }
+      iceRestartInProgress = true;
+      console.log(`Requesting ICE restart (${reason}).`);
+      peerConnection.restartIce();
+    };
+
+    peerConnection.oniceconnectionstatechange = () => {
+      const iceState = peerConnection.iceConnectionState;
+      console.log(`ICE connection state: ${iceState}`);
+
+      switch (iceState) {
+        case "failed":
+          if (iceRestartGraceTimer) { clearTimeout(iceRestartGraceTimer); iceRestartGraceTimer = null; }
+          requestIceRestart("iceConnectionState=failed");
+          break;
+        case "disconnected":
+          if (!iceRestartGraceTimer && !iceRestartInProgress) {
+            iceRestartGraceTimer = setTimeout(() => {
+              iceRestartGraceTimer = null;
+              const current = peerConnection.iceConnectionState;
+              if (current === "disconnected" || current === "failed") {
+                requestIceRestart(`iceConnectionState=${current} after grace period`);
+              }
+            }, 3000);
+          }
+          break;
+        case "connected":
+        case "completed":
+          if (iceRestartGraceTimer) { clearTimeout(iceRestartGraceTimer); iceRestartGraceTimer = null; }
+          iceRestartInProgress = false;
+          break;
+        default:
+          break;
+      }
     };
 
     peerConnection.onicecandidate = async (event) => {
@@ -391,6 +486,7 @@ const startPublishWhip = async (publishSettings, session, callbacks) => {
       type: "answer",
       sdp: answerSDP
     });
+    negotiationEstablished = true; // from here, onnegotiationneeded means an ICE restart
 
     if (publishSettings.useSimulcast && !simulcastAcceptedInAnswer(answerSDP)) {
       reportSimulcastRejection({


### PR DESCRIPTION
# [\[ENG-4469\] Send ICE_RESTART over WebSocket for in-place ICE renegotiation](https://wowzamedia.jira.com/browse/ENG-4469)

Updates the v2 publish and play WebSocket flows to signal a renegotiation as `messageType: "ICE_RESTART"` (carrying the full offer SDP, which the engine normalizes) once the initial offer/answer completes, instead of a plain `OFFER` that the engine now rejects. Tracks `negotiationEstablished` on the session to distinguish the initial offer from a restart, and fixes an adjacent bug where the play repeater-retry call omitted the `session` argument.