### PR TITLE
ENG-4952 - Player fails to start media stream when Chat/Captions enabled and Data Channels disabled server-side

### DIFF
--- a/v2/src/react-example/src/components/play/Player.js
+++ b/v2/src/react-example/src/components/play/Player.js
@@ -6,7 +6,7 @@ import * as WebRTCPlayActions from '../../actions/webrtcPlayActions';
 import * as ErrorsActions from '../../actions/errorsActions';
 import * as DataChannelActions from '../../actions/dataChannelActions';
 import { describeReceivedMessage } from '../../utils/DataChannelUtils';
-import { CHAT_CHANNEL_LABEL, CAPTIONS_CHANNEL_LABEL } from '../../webrtc/attachDataChannel';
+import { CHAT_CHANNEL_LABEL, CAPTIONS_CHANNEL_LABEL, DATA_CHANNELS_UNAVAILABLE_MESSAGE } from '../../webrtc/attachDataChannel';
 
 import startPlay from '../../webrtc/startPlay';
 import stopPlay from '../../webrtc/stopPlay';
@@ -16,6 +16,8 @@ const Player = () => {
   const videoElement = useRef(null);
   const streamRef = useRef(new MediaStream());
   const maxWidthRef = useRef(0);
+  const peerConnectionRef = useRef(undefined);
+  const websocketRef = useRef(undefined);
   const [videoSize, setVideoSize] = useState({ width: 0, height: 0 });
 
   const dispatch = useDispatch();
@@ -27,25 +29,39 @@ const Player = () => {
 
   useEffect(() => {
 
+    const stopCallbacks = {
+      onSetPeerConnection: (result) => {
+        peerConnectionRef.current = result.peerConnection;
+        dispatch({type:WebRTCPlayActions.SET_WEBRTC_PLAY_PEERCONNECTION,peerConnection:result.peerConnection});
+      },
+      onSetWebsocket: (result) => {
+        websocketRef.current = result.websocket;
+        dispatch({type:WebRTCPlayActions.SET_WEBRTC_PLAY_WEBSOCKET,websocket:result.websocket});
+      },
+      onPlayStopped: () => {
+        streamRef.current = new MediaStream();
+        if (videoElement.current) {
+          videoElement.current.srcObject = null;
+        }
+        dispatch({type:WebRTCPlayActions.SET_WEBRTC_PLAY_CONNECTED,connected:false});
+        dispatch(DataChannelActions.resetDataChannel('play'));
+      }
+    };
+
     if (playSettings.playStart && !playSettings.playStarting && !connected)
     {
       dispatch({type:PlaySettingsActions.SET_PLAY_FLAGS, playStart:false, playStarting:true});
       startPlay(playSettings, {
         onError: (error) => {
           dispatch({type:ErrorsActions.SET_ERROR_MESSAGE,message:error.message});
+          stopPlay(playSettings, peerConnectionRef.current, websocketRef.current, stopCallbacks);
           dispatch({ type: PlaySettingsActions.SET_PLAY_FLAGS, playStart: false, playStarting: false, playStop: false, playStopping: false });
-          dispatch({ type: WebRTCPlayActions.SET_WEBRTC_PLAY_CONNECTED, connected: false });
-          dispatch(DataChannelActions.resetDataChannel('play'));
         },
         onConnectionStateChange: (result) => {
           dispatch({type:WebRTCPlayActions.SET_WEBRTC_PLAY_CONNECTED,connected:result.connected});
         },
-        onSetPeerConnection: (result) => {
-          dispatch({type:WebRTCPlayActions.SET_WEBRTC_PLAY_PEERCONNECTION,peerConnection:result.peerConnection});
-        },
-        onSetWebsocket: (result) => {
-          dispatch({type:WebRTCPlayActions.SET_WEBRTC_PLAY_WEBSOCKET,websocket:result.websocket});
-        },
+        onSetPeerConnection: stopCallbacks.onSetPeerConnection,
+        onSetWebsocket: stopCallbacks.onSetWebsocket,
         onPeerConnectionOnTrack: (event) => {
           console.log('ontrack:', event.track.kind, 'muted:', event.track.muted, 'readyState:', event.track.readyState);
           streamRef.current.addTrack(event.track);
@@ -72,6 +88,10 @@ const Player = () => {
         },
         onDataChannelError: (result) => {
           dispatch({type:ErrorsActions.SET_ERROR_MESSAGE, message:'Data channel error: ' + result.message});
+        },
+        onDataChannelsUnavailable: () => {
+          // Playback is unaffected, so this only reports - no media state is touched.
+          dispatch({type:ErrorsActions.SET_ERROR_MESSAGE, message:DATA_CHANNELS_UNAVAILABLE_MESSAGE});
         }
       });
     }
@@ -80,25 +100,12 @@ const Player = () => {
       dispatch({type:PlaySettingsActions.SET_PLAY_FLAGS, playStarting:false});
     }
 
-    if (playSettings.playStop && !playSettings.playStopping && connected)
+    // A session that never reached "connected" still has to be stoppable - otherwise a start that
+    // stalls mid-negotiation leaves the page with no way out.
+    if (playSettings.playStop && !playSettings.playStopping && (connected || peerConnection))
     {
       dispatch({type:PlaySettingsActions.SET_PLAY_FLAGS, playStop:false, playStopping:true});
-      stopPlay(playSettings, peerConnection, websocket,{
-        onSetPeerConnection: (result) => {
-          dispatch({type:WebRTCPlayActions.SET_WEBRTC_PLAY_PEERCONNECTION,peerConnection:result.peerConnection});
-        },
-        onSetWebsocket: (result) => {
-          dispatch({type:WebRTCPlayActions.SET_WEBRTC_PLAY_WEBSOCKET,websocket:result.websocket});
-        },
-        onPlayStopped: () => {
-          streamRef.current = new MediaStream();
-          if (videoElement.current) {
-            videoElement.current.srcObject = null;
-          }
-          dispatch({type:WebRTCPlayActions.SET_WEBRTC_PLAY_CONNECTED,connected:false});
-          dispatch(DataChannelActions.resetDataChannel('play'));
-        }
-      });
+      stopPlay(playSettings, peerConnection, websocket, stopCallbacks);
     }
     if (playSettings.playStopping && !connected)
     {

--- a/v2/src/react-example/src/components/publish/Publisher.js
+++ b/v2/src/react-example/src/components/publish/Publisher.js
@@ -6,6 +6,7 @@ import * as WebRTCPublishActions from '../../actions/webrtcPublishActions';
 import * as ErrorsActions from '../../actions/errorsActions';
 import * as DataChannelActions from '../../actions/dataChannelActions';
 import { describeReceivedMessage } from '../../utils/DataChannelUtils';
+import { DATA_CHANNELS_UNAVAILABLE_MESSAGE } from '../../webrtc/attachDataChannel';
 
 import startPublish from '../../webrtc/startPublish';
 import stopPublish from '../../webrtc/stopPublish';
@@ -59,6 +60,10 @@ const Publisher = () => {
         },
         onDataChannelError: (result) => {
           dispatch({type:ErrorsActions.SET_ERROR_MESSAGE, message:'Data channel error: ' + result.message});
+        },
+        onDataChannelsUnavailable: () => {
+          // Publishing is unaffected, so this only reports - no media state is touched.
+          dispatch({type:ErrorsActions.SET_ERROR_MESSAGE, message:DATA_CHANNELS_UNAVAILABLE_MESSAGE});
         },
         onCaption: (result) => {
           dispatch(DataChannelActions.setCaption('publish', result.text));

--- a/v2/src/react-example/src/utils/IceRestartUtils.js
+++ b/v2/src/react-example/src/utils/IceRestartUtils.js
@@ -9,21 +9,14 @@
 
 const ICE_RESTART_GRACE_PERIOD_MS = 3000;
 
-// Peer connections we have asked for an ICE restart on and still owe a re-offer for. Kept at module
-// level rather than inside attachIceRestartRecovery's closure so that everything which requests a
-// restart can arm it and every onnegotiationneeded handler can consume it, without either side
-// having to hold the recovery handle: the WebSocket flows discard it, and the "Restart ICE" buttons
-// only have the peer connection from the store.
+// Peer connections owing a re-offer. Module-level so requesters and onnegotiationneeded handlers
+// reach it without the recovery handle.
 const pendingRestartOffers = new WeakSet();
 
 const markRestartRequested = (peerConnection) => pendingRestartOffers.add(peerConnection);
 
-// True once per restart we asked for, and false otherwise. Every onnegotiationneeded handler must
-// gate its re-offer on this: the browser also raises negotiationneeded on every return to "stable"
-// when a data channel exists but the server refused the SCTP m-line, and answering those
-// renegotiates forever without ICE ever settling. It has to be one-shot rather than a plain "is a
-// restart in flight" flag, because a restart stays in flight until ICE recovers - and a restart
-// that never recovers would otherwise hold the gate open for exactly those spurious events.
+// Every onnegotiationneeded handler must gate its re-offer on this: the browser re-raises
+// negotiationneeded on every return to "stable" and answering those renegotiates forever.
 export const consumeIceRestartOffer = (peerConnection) => {
   if (!peerConnection || !pendingRestartOffers.has(peerConnection)) {
     console.log('negotiationneeded raised without a pending ICE restart: no re-offer sent.');
@@ -103,9 +96,7 @@ export const attachIceRestartRecovery = (peerConnection) => {
 export const triggerIceRestart = (peerConnection) => {
   if (peerConnection && typeof peerConnection.restartIce === 'function') {
     console.log('[ICE restart] Calling peerConnection.restartIce(); a new offer with fresh ICE credentials will be sent.');
-    // Arm the gate here too, otherwise consumeIceRestartOffer() returns false and the signaling
-    // flow drops the negotiationneeded this restart raises - the restart would never leave the
-    // browser.
+    // Arm the gate, else the negotiationneeded this raises is dropped and nothing reaches the engine.
     markRestartRequested(peerConnection);
     peerConnection.restartIce();
   } else {

--- a/v2/src/react-example/src/utils/IceRestartUtils.js
+++ b/v2/src/react-example/src/utils/IceRestartUtils.js
@@ -9,6 +9,30 @@
 
 const ICE_RESTART_GRACE_PERIOD_MS = 3000;
 
+// Peer connections we have asked for an ICE restart on and still owe a re-offer for. Kept at module
+// level rather than inside attachIceRestartRecovery's closure so that everything which requests a
+// restart can arm it and every onnegotiationneeded handler can consume it, without either side
+// having to hold the recovery handle: the WebSocket flows discard it, and the "Restart ICE" buttons
+// only have the peer connection from the store.
+const pendingRestartOffers = new WeakSet();
+
+const markRestartRequested = (peerConnection) => pendingRestartOffers.add(peerConnection);
+
+// True once per restart we asked for, and false otherwise. Every onnegotiationneeded handler must
+// gate its re-offer on this: the browser also raises negotiationneeded on every return to "stable"
+// when a data channel exists but the server refused the SCTP m-line, and answering those
+// renegotiates forever without ICE ever settling. It has to be one-shot rather than a plain "is a
+// restart in flight" flag, because a restart stays in flight until ICE recovers - and a restart
+// that never recovers would otherwise hold the gate open for exactly those spurious events.
+export const consumeIceRestartOffer = (peerConnection) => {
+  if (!peerConnection || !pendingRestartOffers.has(peerConnection)) {
+    console.log('negotiationneeded raised without a pending ICE restart: no re-offer sent.');
+    return false;
+  }
+  pendingRestartOffers.delete(peerConnection);
+  return true;
+};
+
 // Attaches an oniceconnectionstatechange handler that requests an ICE restart when the
 // connection drops, automatically recovering the session in place.
 export const attachIceRestartRecovery = (peerConnection) => {
@@ -22,6 +46,7 @@ export const attachIceRestartRecovery = (peerConnection) => {
       return;
     }
     iceRestartInProgress = true;
+    markRestartRequested(peerConnection);
     console.log(`Requesting ICE restart (${reason}).`);
     peerConnection.restartIce();
   };
@@ -78,6 +103,10 @@ export const attachIceRestartRecovery = (peerConnection) => {
 export const triggerIceRestart = (peerConnection) => {
   if (peerConnection && typeof peerConnection.restartIce === 'function') {
     console.log('[ICE restart] Calling peerConnection.restartIce(); a new offer with fresh ICE credentials will be sent.');
+    // Arm the gate here too, otherwise consumeIceRestartOffer() returns false and the signaling
+    // flow drops the negotiationneeded this restart raises - the restart would never leave the
+    // browser.
+    markRestartRequested(peerConnection);
     peerConnection.restartIce();
   } else {
     console.warn('[ICE restart] No active peer connection, or restartIce() is unsupported in this browser.');

--- a/v2/src/react-example/src/webrtc/attachDataChannel.js
+++ b/v2/src/react-example/src/webrtc/attachDataChannel.js
@@ -38,8 +38,45 @@ export const CAPTIONS_CHANNEL_LABEL = "captions";
 // never fire. Negotiated channels don't raise "datachannel" on either side, so this stays invisible
 // and doesn't interfere with the real channels. Call once, before createOffer(); one bootstrap
 // covers any number of received channels.
-export const createSctpBootstrap = (peerConnection) => {
+export const createSctpBootstrap = (peerConnection) =>
   peerConnection.createDataChannel("__sctp_bootstrap__", { negotiated: true, id: 0 });
+
+// User-facing copy. Lives here because it pairs with dataChannelsAcceptedInAnswer - keep the
+// wire-level detection and the message it triggers co-located.
+export const DATA_CHANNELS_UNAVAILABLE_MESSAGE =
+  "Data channels are disabled for this application. Chat and captions are unavailable.";
+
+// An SCTP m-section is only usable when the answerer echoes it back with a non-zero port. A port of
+// 0 is a rejection (RFC 3264), and a missing section means the same thing. Media lives in its own
+// m-sections, so a refusal here must never be treated as a session failure.
+export const dataChannelsAcceptedInAnswer = (sdp) => {
+  if (!sdp) return false;
+  const dataSection = sdp.match(/^m=application +(\d+)/m);
+  return dataSection != null && dataSection[1] !== "0";
+};
+
+// Some servers drop the SCTP section from the answer instead of rejecting it in place, which makes
+// setRemoteDescription fail on an m-line count/order mismatch and takes audio and video down with
+// it. Append a rejected stand-in so the answer lines up with the offer and the media sections still
+// apply; dataChannelsAcceptedInAnswer then reports it as refused, as it should.
+export const ensureApplicationSectionInAnswer = (offerSdp, answerSdp) => {
+  if (!offerSdp || !answerSdp) return answerSdp;
+  if (/^m=application /m.test(answerSdp)) return answerSdp;
+
+  // Everything from the offer's m=application line up to the next m-section is the data section.
+  const offerSection = offerSdp.split(/^m=/m).find((section) => section.startsWith("application "));
+  if (!offerSection) return answerSdp;
+
+  const proto = offerSection.split(/\r?\n/)[0].split(" ").slice(2).join(" ");
+  const mid = offerSection.match(/^a=mid:(.*)$/m);
+  const eol = answerSdp.includes("\r\n") ? "\r\n" : "\n";
+
+  const lines = [`m=application 0 ${proto}`, "c=IN IP4 0.0.0.0"];
+  if (mid) lines.push(`a=mid:${mid[1].trim()}`);
+
+  return answerSdp.endsWith(eol)
+    ? answerSdp + lines.join(eol) + eol
+    : answerSdp + eol + lines.join(eol) + eol;
 };
 
 const readyStateToState = (readyState) => {

--- a/v2/src/react-example/src/webrtc/attachDataChannel.js
+++ b/v2/src/react-example/src/webrtc/attachDataChannel.js
@@ -41,29 +41,23 @@ export const CAPTIONS_CHANNEL_LABEL = "captions";
 export const createSctpBootstrap = (peerConnection) =>
   peerConnection.createDataChannel("__sctp_bootstrap__", { negotiated: true, id: 0 });
 
-// User-facing copy. Lives here because it pairs with dataChannelsAcceptedInAnswer - keep the
-// wire-level detection and the message it triggers co-located.
 export const DATA_CHANNELS_UNAVAILABLE_MESSAGE =
   "Data channels are disabled for this application. Chat and captions are unavailable.";
 
-// An SCTP m-section is only usable when the answerer echoes it back with a non-zero port. A port of
-// 0 is a rejection (RFC 3264), and a missing section means the same thing. Media lives in its own
-// m-sections, so a refusal here must never be treated as a session failure.
+// Port 0 is a rejection (RFC 3264); a missing section means the same. Media has its own m-sections,
+// so a refusal here is never a session failure.
 export const dataChannelsAcceptedInAnswer = (sdp) => {
   if (!sdp) return false;
   const dataSection = sdp.match(/^m=application +(\d+)/m);
   return dataSection != null && dataSection[1] !== "0";
 };
 
-// Some servers drop the SCTP section from the answer instead of rejecting it in place, which makes
-// setRemoteDescription fail on an m-line count/order mismatch and takes audio and video down with
-// it. Append a rejected stand-in so the answer lines up with the offer and the media sections still
-// apply; dataChannelsAcceptedInAnswer then reports it as refused, as it should.
+// Some servers drop the SCTP section instead of rejecting it in place, Append a rejected
+// stand-in so the answer lines up with the offer.
 export const ensureApplicationSectionInAnswer = (offerSdp, answerSdp) => {
   if (!offerSdp || !answerSdp) return answerSdp;
   if (/^m=application /m.test(answerSdp)) return answerSdp;
 
-  // Everything from the offer's m=application line up to the next m-section is the data section.
   const offerSection = offerSdp.split(/^m=/m).find((section) => section.startsWith("application "));
   if (!offerSection) return answerSdp;
 

--- a/v2/src/react-example/src/webrtc/captions.js
+++ b/v2/src/react-example/src/webrtc/captions.js
@@ -26,8 +26,7 @@ const CAPTION_PHRASES = [
 // Publisher side: create the captions channel and, once it is open, cycle the phrase pool on a
 // timer, sending one line per tick. `onCaption(text)` (optional) fires for every line sent so the
 // publish UI can mirror what viewers see. Returns a stop() that clears the timer and releases the
-// channel; the timer also self-stops when the channel closes (which the peer connection triggers on
-// teardown, and startPublish does when the server refuses data channels).
+// channel; the timer also self-stops when the channel closes.
 export const startCaptionBroadcast = (peerConnection, onCaption) => {
   const channel = peerConnection.createDataChannel(CAPTIONS_CHANNEL_LABEL);
   let timer = null;

--- a/v2/src/react-example/src/webrtc/captions.js
+++ b/v2/src/react-example/src/webrtc/captions.js
@@ -25,14 +25,15 @@ const CAPTION_PHRASES = [
 
 // Publisher side: create the captions channel and, once it is open, cycle the phrase pool on a
 // timer, sending one line per tick. `onCaption(text)` (optional) fires for every line sent so the
-// publish UI can mirror what viewers see. Returns a stop() that clears the timer; the channel also
-// self-stops on close (which the peer connection triggers on teardown).
+// publish UI can mirror what viewers see. Returns a stop() that clears the timer and releases the
+// channel; the timer also self-stops when the channel closes (which the peer connection triggers on
+// teardown, and startPublish does when the server refuses data channels).
 export const startCaptionBroadcast = (peerConnection, onCaption) => {
   const channel = peerConnection.createDataChannel(CAPTIONS_CHANNEL_LABEL);
   let timer = null;
   let index = 0;
 
-  const stop = () => {
+  const stopTimer = () => {
     if (timer) { clearInterval(timer); timer = null; }
   };
 
@@ -43,14 +44,14 @@ export const startCaptionBroadcast = (peerConnection, onCaption) => {
       try {
         channel.send(text);
       } catch (_) {
-        stop(); // channel went away between ticks; nothing more to send
+        stopTimer(); // channel went away between ticks; nothing more to send
         return;
       }
       if (onCaption) onCaption(text);
     }, CAPTION_INTERVAL_MS);
   };
 
-  channel.onclose = stop;
+  channel.onclose = stopTimer;
 
-  return stop;
+  return () => { stopTimer(); channel.close(); };
 };

--- a/v2/src/react-example/src/webrtc/startPlay.js
+++ b/v2/src/react-example/src/webrtc/startPlay.js
@@ -14,8 +14,8 @@ import attachDataChannel, {
 
 // Listen for whichever data channels are enabled on the player: chat (full-duplex) and/or captions
 // (one-way, receive here). The bootstrap must come first, whenever any channel is enabled, so the
-// SCTP transport is negotiated in the offer and WSE can open the mirrored channels. Returns null
-// when neither is enabled, otherwise a handle to close them if the server refuses the SCTP section.
+// SCTP transport is negotiated in the offer and WSE can open the mirrored channels. Returns a handle
+// to close them if the server refuses the SCTP section.
 const attachPlayDataChannels = (peerConnection, callbacks, playSettings) => {
   if (!playSettings.chatEnabled && !playSettings.captionsEnabled) return null;
   const channels = [createSctpBootstrap(peerConnection)];
@@ -26,10 +26,9 @@ const attachPlayDataChannels = (peerConnection, callbacks, playSettings) => {
   return { close: () => channels.forEach((channel) => channel.close()) };
 };
 
-// The SCTP section is negotiated in the same offer/answer as audio and video, but it is optional:
-// when the application has data channels turned off the answer refuses it and media must still play.
-// Give up on the channels, tell the UI, and leave the session alone. Returns the handle to keep -
-// null once refused, so a later ICE-restart answer doesn't report it twice.
+// The SCTP section shares the offer/answer with media but is optional: give up on the channels, tell
+// the UI, leave the session alone. Returns the handle to keep - null once refused, so a later
+// ICE-restart answer doesn't report it twice.
 const handleRefusedDataChannels = (answerSdp, dataChannels, callbacks) => {
   if (!dataChannels || dataChannelsAcceptedInAnswer(answerSdp)) return dataChannels;
   console.log('Data channels were refused by the server; continuing with media only.');
@@ -152,13 +151,8 @@ const websocketOnOpen = async (playSettings, websocket, callbacks, session) => {
     }
 
     peerConnection.onnegotiationneeded = () => {
-      // The initial play offer is sent explicitly below. The negotiationneeded that addTransceiver()
-      // fires runs before the server assigns a connectionId, so skip it. Re-offer only for a restart
-      // we actually asked for - the browser also raises negotiationneeded on every return to "stable"
-      // once a data channel exists whose m-line the server refused, and answering that renegotiates
-      // forever. The offer carries the fresh ICE credentials restartIce() flagged and goes over the
-      // existing connection as an ICE_RESTART (createOfferPayload picks the message type from
-      // session.negotiationEstablished).
+      // Initial play offer is sent explicitly below, before a connectionId exists; otherwise only
+      // for a restart we asked for.
       if (session.sessionId === '[empty]' || !consumeIceRestartOffer(peerConnection)) return;
       console.log('onnegotiationneeded: sending ICE_RESTART offer over the existing connection.');
       websocketSendPlayGetOffer(playSettings, websocket, peerConnection, callbacks, session);
@@ -228,8 +222,6 @@ const websocketOnMessage = (event, playSettings, peerConnection, websocket, call
       if (message.sdp) {
         console.log("SDP Data: " + message.sdp);
         let sdpData = {
-          // An answer that drops the refused SCTP section instead of rejecting it in place would
-          // fail setRemoteDescription on an m-line mismatch and take media down with it.
           "sdp" : ensureApplicationSectionInAnswer(peerConnection.localDescription.sdp, message.sdp),
           "type": "answer"
         }
@@ -356,8 +348,7 @@ const startPlayWhep = async (playSettings, session, callbacks) => {
     addIceServers(playSettings, session);
     peerConnection = new RTCPeerConnection(session.peerConnectionConfig);
 
-    // Hand it over immediately, as the WebSocket path does: an attempt that fails partway through
-    // still leaves a live connection, and stopPlay can only close what it was given.
+    // Hand it over immediately, as the WebSocket path does: stopPlay can only close what it was given.
     if (callbacks.onSetPeerConnection)
       callbacks.onSetPeerConnection({ peerConnection });
 
@@ -388,9 +379,7 @@ const startPlayWhep = async (playSettings, session, callbacks) => {
     // the existing session and returns its new ICE parameters as an sdpfrag, which we splice into
     // the current answer so playback recovers in place.
     peerConnection.onnegotiationneeded = () => {
-      // The initial WHEP offer is sent manually below, and only a restart we asked for warrants a
-      // re-offer - see the WebSocket handler above for why a refused data m-line would otherwise
-      // renegotiate forever.
+      // Initial WHEP offer is sent manually below; otherwise only for a restart we asked for.
       if (!negotiationEstablished || !sessionUrl || !consumeIceRestartOffer(peerConnection)) return;
       sendWhipWhepIceRestart(peerConnection, sessionUrl, {
         authHeaders: getAuthHeaders(playSettings.authToken),
@@ -450,8 +439,6 @@ const startPlayWhep = async (playSettings, session, callbacks) => {
       pendingCandidates.length = 0;
     }
 
-    // An answer that drops the refused SCTP section instead of rejecting it in place would fail
-    // setRemoteDescription on an m-line mismatch and take media down with it.
     const answerSdp = ensureApplicationSectionInAnswer(
       peerConnection.localDescription.sdp,
       await response.text()

--- a/v2/src/react-example/src/webrtc/startPlay.js
+++ b/v2/src/react-example/src/webrtc/startPlay.js
@@ -2,20 +2,41 @@ import stopPlay from './stopPlay';
 import getSecureToken from './SecureToken';
 import { validateParams } from '../utils/ValidationUtils';
 import { addIceServers } from '../utils/IceServersUtils';
-import { attachIceRestartRecovery } from '../utils/IceRestartUtils';
+import { attachIceRestartRecovery, consumeIceRestartOffer } from '../utils/IceRestartUtils';
 import { sendWhipWhepIceRestart } from '../utils/SdpFragUtils';
-import attachDataChannel, { CHAT_CHANNEL_LABEL, CAPTIONS_CHANNEL_LABEL, createSctpBootstrap } from './attachDataChannel';
+import attachDataChannel, {
+  CHAT_CHANNEL_LABEL,
+  CAPTIONS_CHANNEL_LABEL,
+  createSctpBootstrap,
+  dataChannelsAcceptedInAnswer,
+  ensureApplicationSectionInAnswer,
+} from './attachDataChannel';
 
 // Listen for whichever data channels are enabled on the player: chat (full-duplex) and/or captions
 // (one-way, receive here). The bootstrap must come first, whenever any channel is enabled, so the
-// SCTP transport is negotiated in the offer and WSE can open the mirrored channels.
+// SCTP transport is negotiated in the offer and WSE can open the mirrored channels. Returns null
+// when neither is enabled, otherwise a handle to close them if the server refuses the SCTP section.
 const attachPlayDataChannels = (peerConnection, callbacks, playSettings) => {
-  if (!playSettings.chatEnabled && !playSettings.captionsEnabled) return;
-  createSctpBootstrap(peerConnection);
+  if (!playSettings.chatEnabled && !playSettings.captionsEnabled) return null;
+  const channels = [createSctpBootstrap(peerConnection)];
   if (playSettings.chatEnabled)
-    attachDataChannel(peerConnection, callbacks, { label: CHAT_CHANNEL_LABEL, create: false });
+    channels.push(attachDataChannel(peerConnection, callbacks, { label: CHAT_CHANNEL_LABEL, create: false }));
   if (playSettings.captionsEnabled)
-    attachDataChannel(peerConnection, callbacks, { label: CAPTIONS_CHANNEL_LABEL, create: false });
+    channels.push(attachDataChannel(peerConnection, callbacks, { label: CAPTIONS_CHANNEL_LABEL, create: false }));
+  return { close: () => channels.forEach((channel) => channel.close()) };
+};
+
+// The SCTP section is negotiated in the same offer/answer as audio and video, but it is optional:
+// when the application has data channels turned off the answer refuses it and media must still play.
+// Give up on the channels, tell the UI, and leave the session alone. Returns the handle to keep -
+// null once refused, so a later ICE-restart answer doesn't report it twice.
+const handleRefusedDataChannels = (answerSdp, dataChannels, callbacks) => {
+  if (!dataChannels || dataChannelsAcceptedInAnswer(answerSdp)) return dataChannels;
+  console.log('Data channels were refused by the server; continuing with media only.');
+  dataChannels.close();
+  if (callbacks.onDataChannelsUnavailable)
+    callbacks.onDataChannelsUnavailable();
+  return null;
 };
 
 const getAuthHeaders = (authToken) =>
@@ -132,11 +153,13 @@ const websocketOnOpen = async (playSettings, websocket, callbacks, session) => {
 
     peerConnection.onnegotiationneeded = () => {
       // The initial play offer is sent explicitly below. The negotiationneeded that addTransceiver()
-      // fires runs before the server assigns a connectionId, so skip it. Once connected (a real
-      // connectionId is assigned), a negotiationneeded means restartIce() was called - re-send the offer
-      // (carrying the fresh ICE credentials restartIce() flagged) over the existing connection as an
-      // ICE_RESTART (createOfferPayload picks the message type from session.negotiationEstablished).
-      if (session.sessionId === '[empty]') return;
+      // fires runs before the server assigns a connectionId, so skip it. Re-offer only for a restart
+      // we actually asked for - the browser also raises negotiationneeded on every return to "stable"
+      // once a data channel exists whose m-line the server refused, and answering that renegotiates
+      // forever. The offer carries the fresh ICE credentials restartIce() flagged and goes over the
+      // existing connection as an ICE_RESTART (createOfferPayload picks the message type from
+      // session.negotiationEstablished).
+      if (session.sessionId === '[empty]' || !consumeIceRestartOffer(peerConnection)) return;
       console.log('onnegotiationneeded: sending ICE_RESTART offer over the existing connection.');
       websocketSendPlayGetOffer(playSettings, websocket, peerConnection, callbacks, session);
     };
@@ -147,7 +170,7 @@ const websocketOnOpen = async (playSettings, websocket, callbacks, session) => {
 
     // The data channels must be listened for before the first offer (we never renegotiate). WSE
     // opens the mirrored channels toward the player; the player writes back on chat.
-    attachPlayDataChannels(peerConnection, callbacks, playSettings);
+    session.dataChannels = attachPlayDataChannels(peerConnection, callbacks, playSettings);
 
     websocket.addEventListener("message", (event) => { websocketOnMessage(event, playSettings, peerConnection, websocket, callbacks, session, pendingCandidates); });
 
@@ -205,7 +228,9 @@ const websocketOnMessage = (event, playSettings, peerConnection, websocket, call
       if (message.sdp) {
         console.log("SDP Data: " + message.sdp);
         let sdpData = {
-          "sdp" : message.sdp,
+          // An answer that drops the refused SCTP section instead of rejecting it in place would
+          // fail setRemoteDescription on an m-line mismatch and take media down with it.
+          "sdp" : ensureApplicationSectionInAnswer(peerConnection.localDescription.sdp, message.sdp),
           "type": "answer"
         }
         peerConnection
@@ -214,6 +239,7 @@ const websocketOnMessage = (event, playSettings, peerConnection, websocket, call
             // Initial offer/answer is complete; from here a re-offer is an ICE restart.
             session.negotiationEstablished = true;
             console.log("Remote Description Set Successfully.");
+            session.dataChannels = handleRefusedDataChannels(sdpData.sdp, session.dataChannels, callbacks);
           })
           .catch((err) => peerConnectionOnError(err, callbacks));
       }
@@ -287,6 +313,8 @@ const startPlay = (playSettings, callbacks) =>
       repeaterRetryCount: 0,
       // false until the initial offer/answer completes; afterwards a re-offer is an ICE restart.
       negotiationEstablished: false,
+      // handle to the enabled data channels, cleared once the server refuses them.
+      dataChannels: null,
       peerConnectionConfig: {iceServers: []}
     };
 
@@ -328,6 +356,11 @@ const startPlayWhep = async (playSettings, session, callbacks) => {
     addIceServers(playSettings, session);
     peerConnection = new RTCPeerConnection(session.peerConnectionConfig);
 
+    // Hand it over immediately, as the WebSocket path does: an attempt that fails partway through
+    // still leaves a live connection, and stopPlay can only close what it was given.
+    if (callbacks.onSetPeerConnection)
+      callbacks.onSetPeerConnection({ peerConnection });
+
     peerConnection.addTransceiver("video", { direction: "recvonly" });
     peerConnection.addTransceiver("audio", { direction: "recvonly" });
 
@@ -355,7 +388,10 @@ const startPlayWhep = async (playSettings, session, callbacks) => {
     // the existing session and returns its new ICE parameters as an sdpfrag, which we splice into
     // the current answer so playback recovers in place.
     peerConnection.onnegotiationneeded = () => {
-      if (!negotiationEstablished || !sessionUrl) return; // the initial WHEP offer is sent manually below
+      // The initial WHEP offer is sent manually below, and only a restart we asked for warrants a
+      // re-offer - see the WebSocket handler above for why a refused data m-line would otherwise
+      // renegotiate forever.
+      if (!negotiationEstablished || !sessionUrl || !consumeIceRestartOffer(peerConnection)) return;
       sendWhipWhepIceRestart(peerConnection, sessionUrl, {
         authHeaders: getAuthHeaders(playSettings.authToken),
         label: "WHEP",
@@ -381,7 +417,7 @@ const startPlayWhep = async (playSettings, session, callbacks) => {
     };
 
     // Same as the WebSocket path: listen for the channels before the offer (we never renegotiate).
-    attachPlayDataChannels(peerConnection, callbacks, playSettings);
+    const dataChannels = attachPlayDataChannels(peerConnection, callbacks, playSettings);
 
     const offer = await peerConnection.createOffer();
     await peerConnection.setLocalDescription(offer);
@@ -414,7 +450,12 @@ const startPlayWhep = async (playSettings, session, callbacks) => {
       pendingCandidates.length = 0;
     }
 
-    const answerSdp = await response.text();
+    // An answer that drops the refused SCTP section instead of rejecting it in place would fail
+    // setRemoteDescription on an m-line mismatch and take media down with it.
+    const answerSdp = ensureApplicationSectionInAnswer(
+      peerConnection.localDescription.sdp,
+      await response.text()
+    );
 
     await peerConnection.setRemoteDescription({
       type: "answer",
@@ -423,8 +464,7 @@ const startPlayWhep = async (playSettings, session, callbacks) => {
 
     negotiationEstablished = true; // from here, onnegotiationneeded means an ICE restart
 
-    if (callbacks.onSetPeerConnection)
-      callbacks.onSetPeerConnection({ peerConnection });
+    handleRefusedDataChannels(answerSdp, dataChannels, callbacks);
 
   } catch (error) {
     if (callbacks.onError)

--- a/v2/src/react-example/src/webrtc/startPublish.js
+++ b/v2/src/react-example/src/webrtc/startPublish.js
@@ -8,21 +8,44 @@ import {
   ensureSimulcastSDP,
   simulcastAcceptedInAnswer
 } from "../utils/SimulcastUtils";
-import { attachIceRestartRecovery } from "../utils/IceRestartUtils";
+import { attachIceRestartRecovery, consumeIceRestartOffer } from "../utils/IceRestartUtils";
 import { sendWhipWhepIceRestart } from "../utils/SdpFragUtils";
-import attachDataChannel, { CHAT_CHANNEL_LABEL } from "./attachDataChannel";
+import attachDataChannel, {
+  CHAT_CHANNEL_LABEL,
+  dataChannelsAcceptedInAnswer,
+  ensureApplicationSectionInAnswer
+} from "./attachDataChannel";
 import { startCaptionBroadcast } from "./captions";
 
 // Bring up the enabled publisher data channels: the full-duplex chat channel and/or the one-way
 // captions broadcast, each gated by its own setting. `onCaption` (if provided) mirrors each sent
-// caption line to the UI.
+// caption line to the UI. Returns null when neither is enabled, otherwise a handle to shut them
+// down if the server refuses the SCTP section.
 const attachPublishDataChannels = (peerConnection, callbacks, publishSettings) => {
-  if (publishSettings.chatEnabled)
-    attachDataChannel(peerConnection, callbacks, { label: CHAT_CHANNEL_LABEL, create: true });
+  if (!publishSettings.chatEnabled && !publishSettings.captionsEnabled) return null;
+  const stops = [];
+  if (publishSettings.chatEnabled) {
+    const chat = attachDataChannel(peerConnection, callbacks, { label: CHAT_CHANNEL_LABEL, create: true });
+    stops.push(() => chat.close());
+  }
   if (publishSettings.captionsEnabled)
-    startCaptionBroadcast(peerConnection, (text) => {
+    stops.push(startCaptionBroadcast(peerConnection, (text) => {
       if (callbacks.onCaption) callbacks.onCaption({ text });
-    });
+    }));
+  return { close: () => stops.forEach((stop) => stop()) };
+};
+
+// The SCTP section is negotiated in the same offer/answer as the media, but it is optional: when the
+// application has data channels turned off the answer refuses it and publishing must carry on. Give
+// up on the channels, tell the UI, and leave the session alone. Returns the handle to keep - null
+// once refused, so a later ICE-restart answer doesn't report it twice.
+const handleRefusedDataChannels = (answerSdp, dataChannels, callbacks) => {
+  if (!dataChannels || dataChannelsAcceptedInAnswer(answerSdp)) return dataChannels;
+  console.log("Data channels were refused by the server; continuing with media only.");
+  dataChannels.close();
+  if (callbacks.onDataChannelsUnavailable)
+    callbacks.onDataChannelsUnavailable();
+  return null;
 };
 
 // Orchestration dispatcher: simulcast vs. single-track is a publish-flow
@@ -165,6 +188,11 @@ const websocketOnOpen = (publishSettings, websocket, callbacks, session) => {
     };
 
     peerConnection.onnegotiationneeded = (event) => {
+      // Before the first answer this is what sends the initial offer. Afterwards, re-offer only for
+      // a restart we actually asked for - the browser also raises negotiationneeded on every return
+      // to "stable" once a data channel exists whose m-line the server refused, and answering that
+      // renegotiates forever.
+      if (session.negotiationEstablished && !consumeIceRestartOffer(peerConnection)) return;
       peerConnection.createOffer()
         .then((description) => {
           peerConnectionCreateOfferSuccess(description, publishSettings, websocket, peerConnection, callbacks, session);
@@ -190,7 +218,7 @@ const websocketOnOpen = (publishSettings, websocket, callbacks, session) => {
 
     // The data channels must be created before the first offer (we never renegotiate). The
     // publisher opens whichever of chat / captions are enabled up front.
-    attachPublishDataChannels(peerConnection, callbacks, publishSettings);
+    session.dataChannels = attachPublishDataChannels(peerConnection, callbacks, publishSettings);
 
     let audioSender = undefined;
     let videoSender = undefined;
@@ -241,7 +269,9 @@ const websocketOnMessage = (event, publishSettings, websocket, peerConnection, c
 
     if (msgJSON.message?.sdp) {
       let sdpData = {
-        "sdp": msgJSON.message.sdp,
+        // An answer that drops the refused SCTP section instead of rejecting it in place would fail
+        // setRemoteDescription on an m-line mismatch and take media down with it.
+        "sdp": ensureApplicationSectionInAnswer(peerConnection.localDescription.sdp, msgJSON.message.sdp),
         "type": "answer"
       }
 
@@ -257,7 +287,9 @@ const websocketOnMessage = (event, publishSettings, websocket, peerConnection, c
             reportSimulcastRejection({
               callbacks, peerConnection, websocket
             });
+            return;
           }
+          session.dataChannels = handleRefusedDataChannels(sdpData.sdp, session.dataChannels, callbacks);
         })
         .catch((error) => { peerConnectionOnError(error, callbacks); });
     }
@@ -287,6 +319,8 @@ const startPublish = (publishSettings, websocket, callbacks) =>
         sessionId: '[empty]',
         // false until the initial offer/answer completes; afterwards every re-offer is an ICE restart.
         negotiationEstablished: false,
+        // handle to the enabled data channels, cleared once the server refuses them.
+        dataChannels: null,
         peerConnectionConfig: {iceServers: []}
       };
 
@@ -360,7 +394,10 @@ const startPublishWhip = async (publishSettings, session, callbacks) => {
     // the existing session and returns its new ICE parameters as an sdpfrag, which we splice into
     // the current answer so media recovers without a teardown.
     peerConnection.onnegotiationneeded = () => {
-      if (!negotiationEstablished || !sessionUrl) return; // the initial WHIP offer is sent manually below
+      // The initial WHIP offer is sent manually below, and only a restart we asked for warrants a
+      // re-offer - see the WebSocket handler above for why a refused data m-line would otherwise
+      // renegotiate forever.
+      if (!negotiationEstablished || !sessionUrl || !consumeIceRestartOffer(peerConnection)) return;
       sendWhipWhepIceRestart(peerConnection, sessionUrl, {
         authHeaders: getAuthHeaders(publishSettings.authToken),
         label: "WHIP",
@@ -399,7 +436,7 @@ const startPublishWhip = async (publishSettings, session, callbacks) => {
     // Same as the WebSocket path: create the channels before the offer so their m-lines are
     // negotiated up front (we never renegotiate). onnegotiationneeded is gated until
     // negotiationEstablished, so creating them here does not trigger a spurious WHIP re-offer.
-    attachPublishDataChannels(peerConnection, callbacks, publishSettings);
+    const dataChannels = attachPublishDataChannels(peerConnection, callbacks, publishSettings);
 
     const offer = await peerConnection.createOffer();
     await peerConnection.setLocalDescription(offer);
@@ -435,7 +472,12 @@ const startPublishWhip = async (publishSettings, session, callbacks) => {
     }
     pendingCandidates.length = 0;
 
-    const answerSDP = await response.text();
+    // An answer that drops the refused SCTP section instead of rejecting it in place would fail
+    // setRemoteDescription on an m-line mismatch and take media down with it.
+    const answerSDP = ensureApplicationSectionInAnswer(
+      peerConnection.localDescription.sdp,
+      await response.text()
+    );
 
     console.log("Received WHIP Answer:");
     console.log(answerSDP);
@@ -452,6 +494,8 @@ const startPublishWhip = async (publishSettings, session, callbacks) => {
       });
       return;
     }
+
+    handleRefusedDataChannels(answerSDP, dataChannels, callbacks);
 
     if (callbacks.onSetPeerConnection)
       callbacks.onSetPeerConnection({ peerConnection });

--- a/v2/src/react-example/src/webrtc/startPublish.js
+++ b/v2/src/react-example/src/webrtc/startPublish.js
@@ -19,8 +19,7 @@ import { startCaptionBroadcast } from "./captions";
 
 // Bring up the enabled publisher data channels: the full-duplex chat channel and/or the one-way
 // captions broadcast, each gated by its own setting. `onCaption` (if provided) mirrors each sent
-// caption line to the UI. Returns null when neither is enabled, otherwise a handle to shut them
-// down if the server refuses the SCTP section.
+// caption line to the UI. Returns a handle to shut them down if the server refuses the SCTP section.
 const attachPublishDataChannels = (peerConnection, callbacks, publishSettings) => {
   if (!publishSettings.chatEnabled && !publishSettings.captionsEnabled) return null;
   const stops = [];
@@ -35,10 +34,9 @@ const attachPublishDataChannels = (peerConnection, callbacks, publishSettings) =
   return { close: () => stops.forEach((stop) => stop()) };
 };
 
-// The SCTP section is negotiated in the same offer/answer as the media, but it is optional: when the
-// application has data channels turned off the answer refuses it and publishing must carry on. Give
-// up on the channels, tell the UI, and leave the session alone. Returns the handle to keep - null
-// once refused, so a later ICE-restart answer doesn't report it twice.
+// The SCTP section shares the offer/answer with media but is optional: give up on the channels, tell
+// the UI, leave the session alone. Returns the handle to keep - null once refused, so a later
+// ICE-restart answer doesn't report it twice.
 const handleRefusedDataChannels = (answerSdp, dataChannels, callbacks) => {
   if (!dataChannels || dataChannelsAcceptedInAnswer(answerSdp)) return dataChannels;
   console.log("Data channels were refused by the server; continuing with media only.");
@@ -188,10 +186,8 @@ const websocketOnOpen = (publishSettings, websocket, callbacks, session) => {
     };
 
     peerConnection.onnegotiationneeded = (event) => {
-      // Before the first answer this is what sends the initial offer. Afterwards, re-offer only for
-      // a restart we actually asked for - the browser also raises negotiationneeded on every return
-      // to "stable" once a data channel exists whose m-line the server refused, and answering that
-      // renegotiates forever.
+      // This sends the initial offer; afterwards only for a restart we asked for - see
+      // consumeIceRestartOffer.
       if (session.negotiationEstablished && !consumeIceRestartOffer(peerConnection)) return;
       peerConnection.createOffer()
         .then((description) => {
@@ -269,8 +265,6 @@ const websocketOnMessage = (event, publishSettings, websocket, peerConnection, c
 
     if (msgJSON.message?.sdp) {
       let sdpData = {
-        // An answer that drops the refused SCTP section instead of rejecting it in place would fail
-        // setRemoteDescription on an m-line mismatch and take media down with it.
         "sdp": ensureApplicationSectionInAnswer(peerConnection.localDescription.sdp, msgJSON.message.sdp),
         "type": "answer"
       }
@@ -394,9 +388,7 @@ const startPublishWhip = async (publishSettings, session, callbacks) => {
     // the existing session and returns its new ICE parameters as an sdpfrag, which we splice into
     // the current answer so media recovers without a teardown.
     peerConnection.onnegotiationneeded = () => {
-      // The initial WHIP offer is sent manually below, and only a restart we asked for warrants a
-      // re-offer - see the WebSocket handler above for why a refused data m-line would otherwise
-      // renegotiate forever.
+      // Initial WHIP offer is sent manually below; otherwise only for a restart we asked for.
       if (!negotiationEstablished || !sessionUrl || !consumeIceRestartOffer(peerConnection)) return;
       sendWhipWhepIceRestart(peerConnection, sessionUrl, {
         authHeaders: getAuthHeaders(publishSettings.authToken),
@@ -472,8 +464,6 @@ const startPublishWhip = async (publishSettings, session, callbacks) => {
     }
     pendingCandidates.length = 0;
 
-    // An answer that drops the refused SCTP section instead of rejecting it in place would fail
-    // setRemoteDescription on an m-line mismatch and take media down with it.
     const answerSDP = ensureApplicationSectionInAnswer(
       peerConnection.localDescription.sdp,
       await response.text()

--- a/v2/src/react-example/src/webrtc/stopPlay.js
+++ b/v2/src/react-example/src/webrtc/stopPlay.js
@@ -3,9 +3,14 @@
 // - onSetWebsocket
 // - onPlayStopped
 
-const stopPlay = (playSettings, peerConnection, websocket, callbacks) => 
+const stopPlay = (playSettings, peerConnection, websocket, callbacks) =>
 {
   if (peerConnection != null) {
+    // Detach handlers before closing so a stale connection doesn't fire "closed" / error events
+    // into the next attempt's callbacks.
+    peerConnection.onicecandidate = null;
+    peerConnection.onnegotiationneeded = null;
+    peerConnection.onconnectionstatechange = null;
     peerConnection.close();
     if (callbacks.onSetPeerConnection)
       callbacks.onSetPeerConnection({peerConnection:undefined});

--- a/v2/src/react-example/src/webrtc/stopPlay.js
+++ b/v2/src/react-example/src/webrtc/stopPlay.js
@@ -6,8 +6,6 @@
 const stopPlay = (playSettings, peerConnection, websocket, callbacks) =>
 {
   if (peerConnection != null) {
-    // Detach handlers before closing so a stale connection doesn't fire "closed" / error events
-    // into the next attempt's callbacks.
     peerConnection.onicecandidate = null;
     peerConnection.onnegotiationneeded = null;
     peerConnection.onconnectionstatechange = null;


### PR DESCRIPTION

When Data Channels are disabled for the application in WSEM, enabling Chat or Captions on the player left media dead and both pages flooding the engine with re-offers. The SCTP section is now treated as optional in the offer/answer: media plays either way, and the refusal is reported through the existing error banner on both the play and publish pages.

## Changes made
- **Only re-offer for an ICE restart we actually asked for** — the browser re-raises `negotiationneeded` on every return to `stable` once a data channel exists whose m-line the server refused, and all four handlers answered it unconditionally, renegotiating forever so ICE never settled. A one-shot `WeakSet` of peer connections owing a re-offer now gates them; it lives at module level so both the automatic recovery path and the manual **Restart ICE** buttons arm it without needing the recovery handle. `src/utils/IceRestartUtils.js:17,19,27,49,109`, `src/webrtc/startPlay.js:162,394`, `src/webrtc/startPublish.js:195,400`
- **Detect the refusal on the wire** — `dataChannelsAcceptedInAnswer` treats a missing `m=application` section or a port of `0` as a rejection, and `ensureApplicationSectionInAnswer` appends a rejected stand-in when the server drops the section outright, so `setRemoteDescription` no longer fails on an m-line mismatch and take audio/video down with it. Colocated with `createSctpBootstrap`, mirroring how `SIMULCAST_REJECTED_MESSAGE` sits beside `simulcastAcceptedInAnswer`. `src/webrtc/attachDataChannel.js:41,46,52,62`
- **Degrade instead of failing, identically on both pages** — the data-channel setup helpers now return a close handle, and on refusal the channels are shut down and reported via a new `onDataChannelsUnavailable` callback without touching media state. Replaces the publisher's previous reliance on an incidental, browser-dependent `channel.onerror`. `src/webrtc/startPlay.js:19,33,233,242,455,467`, `src/webrtc/startPublish.js:24,42,274,292,477,498`, `src/components/play/Player.js:92`, `src/components/publish/Publisher.js:9,64-66`
- **Release the captions channel on stop** — `startCaptionBroadcast` returned a `stop()` that only cleared the timer, leaving the channel open when the publisher gives up on data. It now closes the channel too, with the timer-only path kept internal for the `onclose` handler. `src/webrtc/captions.js:36,47,54,56`
- **Make a stalled play session recoverable** — a failed start left the peer connection and websocket alive with their handlers attached, and Stop was gated on `connected` so a session stuck mid-negotiation could not be stopped at all. `stopPlay` now detaches handlers before closing (matching `tearDownConnection` on the publish side), `onError` routes through it, and WHEP hands over the peer connection immediately so a partial failure is still closable. `src/webrtc/stopPlay.js:11`, `src/components/play/Player.js:19,32,57,105`, `src/webrtc/startPlay.js:362`

<details><summary>**How it looks** </summary>
<p>

<img width="1644" height="732" alt="image" src="https://github.com/user-attachments/assets/eec35f20-887c-4a92-824d-535f78724081" />


</p>
</details> 