### PR TITLE
ENG-5031: add simulcast vp9 support

### DIFF
--- a/v2/src/react-example/src/components/publish/PublishSimulcastSettings.js
+++ b/v2/src/react-example/src/components/publish/PublishSimulcastSettings.js
@@ -1,14 +1,15 @@
 import React, { useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import * as PublishSettingsActions from '../../actions/publishSettingsActions';
-import { MAX_SIMULCAST_RENDITIONS, MAX_RID_LENGTH, createSimulcastRendition, sortSimulcastRenditions } from '../../utils/SimulcastUtils';
+import { MAX_SIMULCAST_RENDITIONS, MAX_RID_LENGTH, SCALABILITY_MODE_OPTIONS, createSimulcastRendition, sortSimulcastRenditions } from '../../utils/SimulcastUtils';
 import CollapsibleSection from '../shared/CollapsibleSection';
 
 // Collapsible Simulcast drawer: the on/off toggle plus a table to configure
 // each rendition. Rows are kept in SDP preference order, derived from scale
 // down (highest last); they re-sort when a scale down edit is finished.
-// RID, max bitrate and the number of renditions are negotiated in the offer,
-// so they lock while connected; scale down can change mid-stream.
+// RID, max bitrate, scalability mode and the number of renditions are
+// negotiated in the offer, so they lock while connected; scale down can change
+// mid-stream.
 
 // Scale down edits are kept in a local draft and only dispatched on blur, so
 // a row doesn't jump away while typing and mid-stream setParameters runs once
@@ -56,6 +57,18 @@ const SimulcastRenditionRow = ({ rendition, setupLocked, simulcastDisabled, remo
           disabled={setupLocked}
           onChange={(e) => onFieldChange('maxBitrate', e.target.value)}
         />
+      </td>
+      <td>
+        <select
+          className="form-select form-select-sm"
+          value={rendition.scalabilityMode ?? ''}
+          disabled={setupLocked}
+          onChange={(e) => onFieldChange('scalabilityMode', e.target.value)}
+        >
+          {SCALABILITY_MODE_OPTIONS.map((mode) => (
+            <option key={mode || 'default'} value={mode}>{mode || 'default'}</option>
+          ))}
+        </select>
       </td>
       <td>
         <button
@@ -137,6 +150,7 @@ const PublishSimulcastSettings = () => {
             <th>RID</th>
             <th>Scale Down</th>
             <th>Max Bitrate (bps)</th>
+            <th>Scalability Mode</th>
             <th></th>
           </tr>
         </thead>
@@ -155,6 +169,12 @@ const PublishSimulcastSettings = () => {
           ))}
         </tbody>
       </table>
+
+      <p className="form-text mb-2">
+        Leave Scalability Mode at <code>default</code> for VP8 and H.264. VP9 needs{' '}
+        <code>L1T1</code> on every rendition, otherwise the browser treats the layers as SVC
+        and sends only the first one.
+      </p>
 
       <button
         type="button"

--- a/v2/src/react-example/src/components/publish/PublishSimulcastSettings.js
+++ b/v2/src/react-example/src/components/publish/PublishSimulcastSettings.js
@@ -1,15 +1,14 @@
 import React, { useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import * as PublishSettingsActions from '../../actions/publishSettingsActions';
-import { MAX_SIMULCAST_RENDITIONS, MAX_RID_LENGTH, SCALABILITY_MODE_OPTIONS, createSimulcastRendition, sortSimulcastRenditions } from '../../utils/SimulcastUtils';
+import { MAX_SIMULCAST_RENDITIONS, MAX_RID_LENGTH, createSimulcastRendition, sortSimulcastRenditions } from '../../utils/SimulcastUtils';
 import CollapsibleSection from '../shared/CollapsibleSection';
 
 // Collapsible Simulcast drawer: the on/off toggle plus a table to configure
 // each rendition. Rows are kept in SDP preference order, derived from scale
 // down (highest last); they re-sort when a scale down edit is finished.
-// RID, max bitrate, scalability mode and the number of renditions are
-// negotiated in the offer, so they lock while connected; scale down can change
-// mid-stream.
+// RID, max bitrate and the number of renditions are negotiated in the offer,
+// so they lock while connected; scale down can change mid-stream.
 
 // Scale down edits are kept in a local draft and only dispatched on blur, so
 // a row doesn't jump away while typing and mid-stream setParameters runs once
@@ -57,18 +56,6 @@ const SimulcastRenditionRow = ({ rendition, setupLocked, simulcastDisabled, remo
           disabled={setupLocked}
           onChange={(e) => onFieldChange('maxBitrate', e.target.value)}
         />
-      </td>
-      <td>
-        <select
-          className="form-select form-select-sm"
-          value={rendition.scalabilityMode ?? ''}
-          disabled={setupLocked}
-          onChange={(e) => onFieldChange('scalabilityMode', e.target.value)}
-        >
-          {SCALABILITY_MODE_OPTIONS.map((mode) => (
-            <option key={mode || 'default'} value={mode}>{mode || 'default'}</option>
-          ))}
-        </select>
       </td>
       <td>
         <button
@@ -150,7 +137,6 @@ const PublishSimulcastSettings = () => {
             <th>RID</th>
             <th>Scale Down</th>
             <th>Max Bitrate (bps)</th>
-            <th>Scalability Mode</th>
             <th></th>
           </tr>
         </thead>
@@ -169,12 +155,6 @@ const PublishSimulcastSettings = () => {
           ))}
         </tbody>
       </table>
-
-      <p className="form-text mb-2">
-        Leave Scalability Mode at <code>default</code> for VP8 and H.264. VP9 needs{' '}
-        <code>L1T1</code> on every rendition, otherwise the browser treats the layers as SVC
-        and sends only the first one.
-      </p>
 
       <button
         type="button"

--- a/v2/src/react-example/src/utils/SimulcastUtils.js
+++ b/v2/src/react-example/src/utils/SimulcastUtils.js
@@ -17,17 +17,35 @@ const withRenditionId = (rendition) => ({ ...rendition, id: ++nextRenditionId })
 // rid/scaleResolutionDownBy/maxBitrate is what the browser turns into
 // a=rid / a=simulcast lines in the offer SDP.
 export const DEFAULT_SIMULCAST_RENDITIONS = [
-  { rid: "h", maxBitrate: 2500000, scaleResolutionDownBy: 1.0 },
-  { rid: "m", maxBitrate: 700000, scaleResolutionDownBy: 2.0 },
-  { rid: "l", maxBitrate: 200000, scaleResolutionDownBy: 4.0 }
+  { rid: "h", maxBitrate: 2500000, scaleResolutionDownBy: 1.0, scalabilityMode: "" },
+  { rid: "m", maxBitrate: 700000, scaleResolutionDownBy: 2.0, scalabilityMode: "" },
+  { rid: "l", maxBitrate: 200000, scaleResolutionDownBy: 4.0, scalabilityMode: "" }
 ].map(withRenditionId);
 
 export const createSimulcastRendition = () => {
-  return withRenditionId({ rid: "", scaleResolutionDownBy: 1, maxBitrate: 500000 });
+  return withRenditionId({ rid: "", scaleResolutionDownBy: 1, maxBitrate: 500000, scalabilityMode: "" });
 };
 
 // RFC 8851 rid-id: letters, digits, "-" and "_"
 const RID_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+// WebRTC-SVC scalability mode. Two supported values, and this list is the only
+// definition of them: the dropdown renders it and the validator checks against
+// it, so the UI and what is accepted cannot drift apart.
+//
+// Empty sends no scalabilityMode at all, which is what VP8 and H.264 want:
+// several encodings are enough on their own, the browser runs one encoder per
+// layer. VP9 is the exception. Its encoder expresses layers as SVC inside a
+// single RTP stream, so several encodings collapse to one unless each declares a
+// single-spatial-layer mode, and only the first rid reaches the wire. L1T1 is
+// that declaration: one spatial layer, one temporal layer, one independent
+// stream per encoding.
+//
+// Nothing else is supported. Multi-spatial modes (L2*, L3*) cannot be combined
+// with simulcast on one transceiver at all, and multi-temporal ones (L1T2,
+// L1T3) would only add layering a Wowza server neither records on ingest nor
+// signals downstream.
+export const SCALABILITY_MODE_OPTIONS = ["", "L1T1"];
 
 // User-facing copy. Lives here because it pairs with simulcastAcceptedInAnswer —
 // keep the wire-level detection and the message it triggers co-located.
@@ -56,6 +74,11 @@ export const getSimulcastRenditionsError = (renditions) => {
       return `Invalid resolution scale down for "${rendition.rid}": must be 1 or greater`;
     if (!(Number(rendition.maxBitrate) > 0))
       return `Invalid max bitrate for "${rendition.rid}": must be greater than 0`;
+
+    const scalabilityMode = rendition.scalabilityMode ?? "";
+    if (!SCALABILITY_MODE_OPTIONS.includes(scalabilityMode))
+      return `Invalid scalability mode for "${rendition.rid}": use L1T1, or leave it unset for `
+        + `VP8 and H.264. No other mode is supported.`;
   }
   return null;
 };
@@ -80,7 +103,8 @@ export const parseSimulcastRenditions = (value) => {
   const normalized = renditions.map((rendition) => withRenditionId({
     rid: String(rendition?.rid ?? ""),
     scaleResolutionDownBy: Number(rendition?.scaleResolutionDownBy) || 1,
-    maxBitrate: Number(rendition?.maxBitrate) || 0
+    maxBitrate: Number(rendition?.maxBitrate) || 0,
+    scalabilityMode: String(rendition?.scalabilityMode ?? "").trim()
   }));
 
   return getSimulcastRenditionsError(normalized) ? null : sortSimulcastRenditions(normalized);
@@ -93,6 +117,10 @@ const buildSendEncodings = (renditions) => {
     if (scale > 1) encoding.scaleResolutionDownBy = scale;
     const maxBitrate = Number(rendition.maxBitrate);
     if (maxBitrate > 0) encoding.maxBitrate = maxBitrate;
+    // Omitted unless set: an unset mode is what VP8 and H.264 expect, and it
+    // leaves the browser's own default in place.
+    const scalabilityMode = (rendition.scalabilityMode ?? "").trim();
+    if (scalabilityMode !== "") encoding.scalabilityMode = scalabilityMode;
     return encoding;
   });
 };

--- a/v2/src/react-example/src/utils/SimulcastUtils.js
+++ b/v2/src/react-example/src/utils/SimulcastUtils.js
@@ -17,35 +17,31 @@ const withRenditionId = (rendition) => ({ ...rendition, id: ++nextRenditionId })
 // rid/scaleResolutionDownBy/maxBitrate is what the browser turns into
 // a=rid / a=simulcast lines in the offer SDP.
 export const DEFAULT_SIMULCAST_RENDITIONS = [
-  { rid: "h", maxBitrate: 2500000, scaleResolutionDownBy: 1.0, scalabilityMode: "" },
-  { rid: "m", maxBitrate: 700000, scaleResolutionDownBy: 2.0, scalabilityMode: "" },
-  { rid: "l", maxBitrate: 200000, scaleResolutionDownBy: 4.0, scalabilityMode: "" }
+  { rid: "h", maxBitrate: 2500000, scaleResolutionDownBy: 1.0 },
+  { rid: "m", maxBitrate: 700000, scaleResolutionDownBy: 2.0 },
+  { rid: "l", maxBitrate: 200000, scaleResolutionDownBy: 4.0 }
 ].map(withRenditionId);
 
 export const createSimulcastRendition = () => {
-  return withRenditionId({ rid: "", scaleResolutionDownBy: 1, maxBitrate: 500000, scalabilityMode: "" });
+  return withRenditionId({ rid: "", scaleResolutionDownBy: 1, maxBitrate: 500000 });
 };
 
 // RFC 8851 rid-id: letters, digits, "-" and "_"
 const RID_PATTERN = /^[A-Za-z0-9_-]+$/;
 
-// WebRTC-SVC scalability mode. Two supported values, and this list is the only
-// definition of them: the dropdown renders it and the validator checks against
-// it, so the UI and what is accepted cannot drift apart.
+// WebRTC-SVC scalability mode declared on every simulcast encoding: one spatial
+// layer, one temporal layer, so each encoding stays an independent stream.
 //
-// Empty sends no scalabilityMode at all, which is what VP8 and H.264 want:
-// several encodings are enough on their own, the browser runs one encoder per
-// layer. VP9 is the exception. Its encoder expresses layers as SVC inside a
-// single RTP stream, so several encodings collapse to one unless each declares a
-// single-spatial-layer mode, and only the first rid reaches the wire. L1T1 is
-// that declaration: one spatial layer, one temporal layer, one independent
-// stream per encoding.
+// VP8 and H.264 do not need it, several encodings are enough on their own. VP9
+// does: its encoder expresses layers as SVC inside a single RTP stream, so
+// several encodings collapse to one and only the first rid reaches the wire
+// unless each declares a single spatial layer.
 //
-// Nothing else is supported. Multi-spatial modes (L2*, L3*) cannot be combined
-// with simulcast on one transceiver at all, and multi-temporal ones (L1T2,
-// L1T3) would only add layering a Wowza server neither records on ingest nor
-// signals downstream.
-export const SCALABILITY_MODE_OPTIONS = ["", "L1T1"];
+// It is applied unconditionally rather than only for VP9, because encodings are
+// fixed at addTransceiver, before the answer says which codec was negotiated.
+// There is no moment at which the page could know to apply it selectively, and
+// setParameters after the answer does not start encoders that never ran.
+const SIMULCAST_SCALABILITY_MODE = "L1T1";
 
 // User-facing copy. Lives here because it pairs with simulcastAcceptedInAnswer —
 // keep the wire-level detection and the message it triggers co-located.
@@ -74,11 +70,6 @@ export const getSimulcastRenditionsError = (renditions) => {
       return `Invalid resolution scale down for "${rendition.rid}": must be 1 or greater`;
     if (!(Number(rendition.maxBitrate) > 0))
       return `Invalid max bitrate for "${rendition.rid}": must be greater than 0`;
-
-    const scalabilityMode = rendition.scalabilityMode ?? "";
-    if (!SCALABILITY_MODE_OPTIONS.includes(scalabilityMode))
-      return `Invalid scalability mode for "${rendition.rid}": use L1T1, or leave it unset for `
-        + `VP8 and H.264. No other mode is supported.`;
   }
   return null;
 };
@@ -103,8 +94,7 @@ export const parseSimulcastRenditions = (value) => {
   const normalized = renditions.map((rendition) => withRenditionId({
     rid: String(rendition?.rid ?? ""),
     scaleResolutionDownBy: Number(rendition?.scaleResolutionDownBy) || 1,
-    maxBitrate: Number(rendition?.maxBitrate) || 0,
-    scalabilityMode: String(rendition?.scalabilityMode ?? "").trim()
+    maxBitrate: Number(rendition?.maxBitrate) || 0
   }));
 
   return getSimulcastRenditionsError(normalized) ? null : sortSimulcastRenditions(normalized);
@@ -112,24 +102,22 @@ export const parseSimulcastRenditions = (value) => {
 
 const buildSendEncodings = (renditions) => {
   return sortSimulcastRenditions(renditions).map((rendition) => {
-    const encoding = { rid: rendition.rid };
+    const encoding = { rid: rendition.rid, scalabilityMode: SIMULCAST_SCALABILITY_MODE };
     const scale = Number(rendition.scaleResolutionDownBy);
     if (scale > 1) encoding.scaleResolutionDownBy = scale;
     const maxBitrate = Number(rendition.maxBitrate);
     if (maxBitrate > 0) encoding.maxBitrate = maxBitrate;
-    // Omitted unless set: an unset mode is what VP8 and H.264 expect, and it
-    // leaves the browser's own default in place.
-    const scalabilityMode = (rendition.scalabilityMode ?? "").trim();
-    if (scalabilityMode !== "") encoding.scalabilityMode = scalabilityMode;
     return encoding;
   });
 };
 
 // Returns the RTCRtpSender so callers match the contract of addTrack().
 export const addSimulcastVideoSender = (peerConnection, videoTrack, renditions) => {
+  const sendEncodings = buildSendEncodings(renditions);
+
   const transceiver = peerConnection.addTransceiver(videoTrack, {
     direction: "sendonly",
-    sendEncodings: buildSendEncodings(renditions)
+    sendEncodings
   });
   return transceiver.sender;
 };


### PR DESCRIPTION
# [ENG-5031] Declare a single-layer scalability mode on simulcast encodings for VP9

> Ticket [ENG-5031](https://wowzamedia.jira.com/browse/ENG-5031)

Publishing with Simulcast against an application that negotiates VP9 sent only the first rid: libwebrtc expresses VP9 layers as SVC inside a single RTP stream, so several encodings collapse unless each declares one spatial layer. Every simulcast encoding now carries `scalabilityMode: "L1T1"`, which makes VP9 behave like VP8. Verified against WSE: all three rids bind on both the publish and the WHIP-pushed group, where previously only `h` did.

## Changes made
- **`scalabilityMode: "L1T1"` on every simulcast encoding**, declaring one spatial and one temporal layer so each encoding stays an independent stream. VP8 and H.264 do not need it; VP9 does. `v2/src/react-example/src/utils/SimulcastUtils.js:32-44,103-110`
- **Applied unconditionally rather than only for VP9**, because `sendEncodings` is fixed at `addTransceiver`, before the answer says which codec was negotiated. There is no point at which the page could apply it selectively, and `setParameters` after the answer does not start encoders that never ran. The constant and the comment above it carry that reasoning. `v2/src/react-example/src/utils/SimulcastUtils.js:32-44`
- **A `console.info` on publish** naming the mode and the rids it was applied to, so a developer reading the console sees that the page added something they did not configure, and why. No UI surface: there is no per-rendition case for changing this, and a form field would only be one more thing to get wrong. `v2/src/react-example/src/utils/SimulcastUtils.js:115-127`

