### PR TITLE
ENG-5096: Add GitHub repo link to v2 example pages nav

### DIFF
--- a/v2/src/react-example/src/components/shell/Nav.js
+++ b/v2/src/react-example/src/components/shell/Nav.js
@@ -89,6 +89,9 @@ const Nav = (props) => {
         <li className="nav-item mr-3">
           <a href="https://developer.wowza.com">Developer Portal</a>
         </li>
+        <li className="nav-item mr-3">
+          <a href="https://github.com/WowzaMediaSystems/webrtc-examples" target="_blank" rel="noopener noreferrer">GitHub</a>
+        </li>
       </ul>
     </nav>
   );


### PR DESCRIPTION
## Summary

Adds a **GitHub** link to the top navigation of the v2 example pages, pointing to [WowzaMediaSystems/webrtc-examples](https://github.com/WowzaMediaSystems/webrtc-examples). The public pages on wowza.com are built from this repo, and users had no way to reach the source code from the pages themselves.

## Changes

- Add a "GitHub" item to the right-hand nav list in `Nav.js`, next to Docs and Developer Portal. Opens in a new tab.
- Since `Nav` is shared, the link shows up on all four v2 pages (publish, play, meeting, composite).

## Notes

- v1 pages are not touched.
- The right-hand nav list already has `d-none d-md-flex`, so the new link is hidden below 768px like the existing Docs and Developer Portal links. Kept for consistency.

